### PR TITLE
Update to latest notification library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
   "com.gu" %% "content-api-client" % "11.55",
-  "com.gu" %% "mobile-notifications-client" % "1.1",
+  "com.gu" %% "mobile-notifications-client" % "1.2",
   "org.apache.thrift" % "libthrift" % "0.9.1",
   "org.joda" % "joda-convert" % "1.8.1",
   "org.jsoup" % "jsoup" % "1.8.3",


### PR DESCRIPTION
- Topics are only of type contributor, series or blog so we filter through as keywords aren't followable anymore (for years)
- Order of topic is important now as we want to pick the first three only
- Only send a notification to three topics