### PR TITLE
Add fallback case

### DIFF
--- a/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
@@ -58,6 +58,9 @@ trait Lambda extends Logging {
             case UnknownUnionField(e) =>
               logger.error(s"Unknown event payload $e. Consider updating capi models")
               Future.successful(false)
+            case _ =>
+              logger.warn(s"Unknown event payload ${event.payload}. Consider updating capi models")
+              Future.successful(false)
           }.getOrElse(Future.successful(false))
         case _ =>
           logger.info("Received non-updatable event type")


### PR DESCRIPTION
This fixes the production error observed on the 07th of December.

Observed behaviour:
A large amount of atom events were published on the kinesis stream, large enough such that the retries would saturate the lambda, stalling any processing. Regular publication events would not be processed anymore.