### PR TITLE
Give more memory to the lambdas

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -125,7 +125,7 @@ Resources:
           Stage: !Sub ${Stage}
       Description: Lambda to send notification when new content is published
       Handler: com.gu.mobile.content.notifications.ContentLambda::handler
-      MemorySize: 384
+      MemorySize: 1024
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
       Timeout: 60
@@ -154,7 +154,7 @@ Resources:
           Stage: !Sub ${Stage}
       Description: Lambda that sends push notifications when new key events are published on a liveblog
       Handler: com.gu.mobile.content.notifications.LiveBlogLambda::handler
-      MemorySize: 384
+      MemorySize: 1024
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
       Timeout: 60


### PR DESCRIPTION
Giving more memory to the lambdas such that we limit the number of Out Of Memory errors (Metaspace).
I spotted a couple in the past 24 hours