### PR TITLE
No "Following: " prefix for the aus morning mail and us morning briefing

### DIFF
--- a/src/main/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilder.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilder.scala
@@ -24,7 +24,9 @@ trait ContentAlertPayloadBuilder extends Logging {
     Topic(TagSeries, "membership/series/weekend-round-up"),
     Topic(TagSeries, "world/series/guardian-morning-briefing"),
     Topic(TagSeries, "politics/series/the-snap"),
-    Topic(TagSeries, "us-news/series/the-campaign-minute-2016")
+    Topic(TagSeries, "us-news/series/the-campaign-minute-2016"),
+    Topic(TagSeries, "australia-news/series/guardian-australia-s-morning-mail"),
+    Topic(TagSeries, "us-news/series/guardian-us-briefing")
   )
 
   private val followableTopicTypes: Set[TagType] = Set(TagType.Series, TagType.Blog, TagType.Contributor)


### PR DESCRIPTION
This is following a chat with Editorial. I figured I could write a ticket or just do it :)