### PR TITLE
MSS-1268: Remove kicker duplication for series

### DIFF
--- a/src/main/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilder.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilder.scala
@@ -18,15 +18,10 @@ trait ContentAlertPayloadBuilder extends Logging {
   val config: Configuration
 
   private val topicsWithoutPrefix = Set(
-    Topic(TagSeries, "football/series/the-uefa-euro-minute-2016"),
-    Topic(TagSeries, "sport/series/the-olympic-games-minute-2016"),
-    Topic(TagSeries, "membership/series/weekend-reading"),
-    Topic(TagSeries, "membership/series/weekend-round-up"),
     Topic(TagSeries, "world/series/guardian-morning-briefing"),
-    Topic(TagSeries, "politics/series/the-snap"),
-    Topic(TagSeries, "us-news/series/the-campaign-minute-2016"),
     Topic(TagSeries, "australia-news/series/guardian-australia-s-morning-mail"),
-    Topic(TagSeries, "us-news/series/guardian-us-briefing")
+    Topic(TagSeries, "us-news/series/guardian-us-briefing"),
+    Topic(TagSeries, "politics/series/andrew-sparrows-election-briefing")
   )
 
   private val followableTopicTypes: Set[TagType] = Set(TagType.Series, TagType.Blog, TagType.Contributor)

--- a/src/test/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilderSpec.scala
+++ b/src/test/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilderSpec.scala
@@ -128,22 +128,6 @@ class ContentAlertPayloadBuilderSpec extends MockitoSugar with WordSpecLike with
       load mustEqual expectedPayloadWithImages
     }
 
-    "do not prefix title for weekend round up" in {
-      val tag = Tag("membership/series/weekend-round-up", TagType.Series, None, None, "Steve", "", "")
-      val topic = Topic(TagSeries, "membership/series/weekend-round-up")
-      val minuteItem = item.copy(tags = List(tag))
-      val expectedMinutePayload = expectedPayloadForItem.copy(title = None, topic = List(topic))
-      builder.buildPayLoad(minuteItem) mustEqual expectedMinutePayload
-    }
-
-    "do not prefix title for weekend reading" in {
-      val tag = Tag("membership/series/weekend-reading", TagType.Series, None, None, "Steve", "", "")
-      val topic = Topic(TagSeries, "membership/series/weekend-reading")
-      val minuteItem = item.copy(tags = List(tag))
-      val expectedMinutePayload = expectedPayloadForItem.copy(title = None, topic = List(topic))
-      builder.buildPayLoad(minuteItem) mustEqual expectedMinutePayload
-    }
-
     "do not prefix title for guardian-morning-briefing" in {
       val tag = Tag("world/series/guardian-morning-briefing", TagType.Series, None, None, "Steve", "", "")
       val topic = Topic(TagSeries, "world/series/guardian-morning-briefing")
@@ -151,15 +135,29 @@ class ContentAlertPayloadBuilderSpec extends MockitoSugar with WordSpecLike with
       val expectedPayload = expectedPayloadForItem.copy(title = None, topic = List(topic))
       builder.buildPayLoad(contentItem) mustEqual expectedPayload
     }
-
-    "use a specific title for the minute notification" in {
-      val briefingTag = Tag("us-news/series/the-campaign-minute-2016", TagType.Series, None, None, "Steve", "", "")
-      val briefingTopic = Topic(TagSeries, "us-news/series/the-campaign-minute-2016")
-      val expectedTitle = "headline"
-      val contentItem = item.copy(tags = List(briefingTag))
-      val expectedMinutePayload = expectedPayloadForItem.copy(title = None, topic = List(briefingTopic))
-      builder.buildPayLoad(contentItem) mustBe expectedMinutePayload
-
+    
+    "do not prefix title for andrew-sparrows-election-briefing" in {
+      val tag = Tag("politics/series/andrew-sparrows-election-briefing", TagType.Series, None, None, "Steve", "", "")
+      val topic = Topic(TagSeries, "politics/series/andrew-sparrows-election-briefing")
+      val contentItem = item.copy(tags = List(tag))
+      val expectedPayload = expectedPayloadForItem.copy(title = None, topic = List(topic))
+      builder.buildPayLoad(contentItem) mustEqual expectedPayload
+    }
+    
+    "do not prefix title for guardian-australia-s-morning-mail" in {
+      val tag = Tag("australia-news/series/guardian-australia-s-morning-mail", TagType.Series, None, None, "Steve", "", "")
+      val topic = Topic(TagSeries, "australia-news/series/guardian-australia-s-morning-mail")
+      val contentItem = item.copy(tags = List(tag))
+      val expectedPayload = expectedPayloadForItem.copy(title = None, topic = List(topic))
+      builder.buildPayLoad(contentItem) mustEqual expectedPayload
+    }
+    
+    "do not prefix title for guardian-us-briefing" in {
+      val tag = Tag("us-news/series/guardian-us-briefing", TagType.Series, None, None, "Steve", "", "")
+      val topic = Topic(TagSeries, "politics/series/andrew-sparrows-election-briefing")
+      val contentItem = item.copy(tags = List(tag))
+      val expectedPayload = expectedPayloadForItem.copy(title = None, topic = List(topic))
+      builder.buildPayLoad(contentItem) mustEqual expectedPayload
     }
 
     "should have a maximum of 3 topics" in {

--- a/src/test/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilderSpec.scala
+++ b/src/test/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilderSpec.scala
@@ -154,7 +154,7 @@ class ContentAlertPayloadBuilderSpec extends MockitoSugar with WordSpecLike with
     
     "do not prefix title for guardian-us-briefing" in {
       val tag = Tag("us-news/series/guardian-us-briefing", TagType.Series, None, None, "Steve", "", "")
-      val topic = Topic(TagSeries, "politics/series/andrew-sparrows-election-briefing")
+      val topic = Topic(TagSeries, "us-news/series/guardian-us-briefing")
       val contentItem = item.copy(tags = List(tag))
       val expectedPayload = expectedPayloadForItem.copy(title = None, topic = List(topic))
       builder.buildPayLoad(contentItem) mustEqual expectedPayload


### PR DESCRIPTION
https://theguardian.atlassian.net/browse/MSS-1268

As requested by Celine, this PR removes the "kicker" from notifications sent for [Andrew Sparrow's election briefing](https://www.theguardian.com/politics/series/andrew-sparrows-election-briefing).

This is the quick and easy solution, given that series won't be relevant in another week's time, but we could (and IMHO should) also think about a long-term approach to have the series in notification titles instead of having them in the body.

Speaking of series that are not relevant anymore, I've used the opportunity to remove the code for a few ones that have been discontinued.