### PR TITLE
MSS-1257: Allow multiple contributors for notification title

### DIFF
--- a/src/main/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilder.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilder.scala
@@ -27,9 +27,15 @@ trait ContentAlertPayloadBuilder extends Logging {
   private val followableTopicTypes: Set[TagType] = Set(TagType.Series, TagType.Blog, TagType.Contributor)
 
   def buildPayLoad(content: Content): ContentAlertPayload = {
-    val followableTag: Option[Tag] = content.tags.findOne(_.`type` == TagType.Series)
-      .orElse(content.tags.findOne(_.`type` == TagType.Blog))
-      .orElse(content.tags.findOne(_.`type` == TagType.Contributor))
+    val tagTypeSeries: Option[Tag] = content.tags.findOne(_.`type` == TagType.Series)
+    val tagTypeBlog: Option[Tag] = content.tags.findOne(_.`type` == TagType.Blog)
+    val tagTypeContributor: List[Tag] = content.tags.filter(_.`type` == TagType.Contributor).toList
+
+    val followableTag: List[Tag] = (tagTypeSeries, tagTypeBlog, tagTypeContributor) match {
+      case (Some(tagSeries), _, _) => List(tagSeries)
+      case (None, Some(tagBlog), _) => List(tagBlog)
+      case (None, None, tagContributor) => tagContributor.take(3)
+    }
 
     val topics = content.tags
       .filter(tag => followableTopicTypes.contains(tag.`type`))
@@ -77,11 +83,11 @@ trait ContentAlertPayloadBuilder extends Logging {
     getTopicType(tag.`type`) map { tagType => Topic(tagType, tag.id) }
   }
 
-  private def contentTitle(followableTag: Option[Tag], topics: List[Topic]): Option[String] =
+  private def contentTitle(followableTag: List[Tag], topics: List[Topic]): Option[String] =
     if (topics.toSet.intersect(topicsWithoutPrefix).nonEmpty) {
       None
     } else {
-      followableTag.map { ft => ft.webTitle }.orElse(Some("Following"))
+      Some(followableTag.map { ft => ft.webTitle }.mkString(","))
     }
 
   private def selectMainImage(content: Content, minWidth: Int): Option[String] = {

--- a/src/main/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilder.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilder.scala
@@ -87,7 +87,7 @@ trait ContentAlertPayloadBuilder extends Logging {
     if (topics.toSet.intersect(topicsWithoutPrefix).nonEmpty) {
       None
     } else {
-      Some(followableTag.map { ft => ft.webTitle }.mkString(","))
+      Some(followableTag.map { ft => ft.webTitle }.mkString(", "))
     }
 
   private def selectMainImage(content: Content, minWidth: Int): Option[String] = {

--- a/src/test/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilderSpec.scala
+++ b/src/test/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilderSpec.scala
@@ -69,7 +69,7 @@ class ContentAlertPayloadBuilderSpec extends MockitoSugar with WordSpecLike with
   )
 
   val expectedPayloadForItem = ContentAlertPayload(
-    title = Some("Following"),
+    title = Some(TagContributor.toString),
     message = Some("headline"),
     thumbnailUrl = Some(new URI(thumb)),
     sender = "mobile-notifications-content",
@@ -111,8 +111,8 @@ class ContentAlertPayloadBuilderSpec extends MockitoSugar with WordSpecLike with
       verifyContentAlert(tags = List(contributorTag, keywordTag), expectedReason = contributorTag.webTitle)
     }
 
-    "not use contributor tags in web title if there is more than one" in {
-      verifyContentAlert(tags = List(contributorTag, keywordTag, contributorTag2), expectedReason = "Following")
+    "should use multiple contributor tags in web title if there is more than one" in {
+      verifyContentAlert(tags = List(contributorTag, keywordTag, contributorTag2), expectedReason = contributorTag.webTitle ++ "," ++ contributorTag2.webTitle)
     }
 
     "use no imageUri if no image is found" in {
@@ -164,7 +164,7 @@ class ContentAlertPayloadBuilderSpec extends MockitoSugar with WordSpecLike with
       val manyTags = (1 to 25).toList.map(index => Tag(s"idKeyword_$index", TagType.Contributor, None, None, s"World_$index", "", ""))
       val contentItem = item.copy(tags = manyTags)
       val expectedTopics = manyTags.map(tag => Topic(TagContributor, tag.id)).take(3)
-      val expectedPayload = expectedPayloadForItem.copy(title = Some("Following"), message = Some("headline"), topic = expectedTopics)
+      val expectedPayload = expectedPayloadForItem.copy(title = Some(s"World_1,World_2,World_3"), message = Some("headline"), topic = expectedTopics)
 
       builder.buildPayLoad(contentItem) mustEqual expectedPayload
     }

--- a/src/test/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilderSpec.scala
+++ b/src/test/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilderSpec.scala
@@ -112,7 +112,7 @@ class ContentAlertPayloadBuilderSpec extends MockitoSugar with WordSpecLike with
     }
 
     "should use multiple contributor tags in web title if there is more than one" in {
-      verifyContentAlert(tags = List(contributorTag, keywordTag, contributorTag2), expectedReason = contributorTag.webTitle ++ "," ++ contributorTag2.webTitle)
+      verifyContentAlert(tags = List(contributorTag, keywordTag, contributorTag2), expectedReason = contributorTag.webTitle ++ ", " ++ contributorTag2.webTitle)
     }
 
     "use no imageUri if no image is found" in {
@@ -164,7 +164,7 @@ class ContentAlertPayloadBuilderSpec extends MockitoSugar with WordSpecLike with
       val manyTags = (1 to 25).toList.map(index => Tag(s"idKeyword_$index", TagType.Contributor, None, None, s"World_$index", "", ""))
       val contentItem = item.copy(tags = manyTags)
       val expectedTopics = manyTags.map(tag => Topic(TagContributor, tag.id)).take(3)
-      val expectedPayload = expectedPayloadForItem.copy(title = Some(s"World_1,World_2,World_3"), message = Some("headline"), topic = expectedTopics)
+      val expectedPayload = expectedPayloadForItem.copy(title = Some(s"World_1, World_2, World_3"), message = Some("headline"), topic = expectedTopics)
 
       builder.buildPayLoad(contentItem) mustEqual expectedPayload
     }


### PR DESCRIPTION
When an item has multiple contributors, rather than "Following" we want to see all the names of the authors.