### PR TITLE
MSS-1267: Amend notification title for Opinion tag type

### DIFF
--- a/src/main/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilder.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilder.scala
@@ -29,7 +29,7 @@ trait ContentAlertPayloadBuilder extends Logging {
   def buildPayLoad(content: Content): ContentAlertPayload = {
     val tagTypeSeries: Option[Tag] = content.tags.findOne(_.`type` == TagType.Series)
     val tagTypeBlog: Option[Tag] = content.tags
-      .filterNot(tag => tag.sectionId.contains("commentisfree"))
+      .filterNot(tag => tag.id.contains("commentisfree/commentisfree"))
       .findOne(_.`type` == TagType.Blog)
     val tagTypeContributor: List[Tag] = content.tags.filter(_.`type` == TagType.Contributor).toList
 

--- a/src/main/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilder.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilder.scala
@@ -28,7 +28,9 @@ trait ContentAlertPayloadBuilder extends Logging {
 
   def buildPayLoad(content: Content): ContentAlertPayload = {
     val tagTypeSeries: Option[Tag] = content.tags.findOne(_.`type` == TagType.Series)
-    val tagTypeBlog: Option[Tag] = content.tags.findOne(_.`type` == TagType.Blog)
+    val tagTypeBlog: Option[Tag] = content.tags
+      .filterNot(tag => tag.sectionId.contains("commentisfree"))
+      .findOne(_.`type` == TagType.Blog)
     val tagTypeContributor: List[Tag] = content.tags.filter(_.`type` == TagType.Contributor).toList
 
     val followableTag: List[Tag] = (tagTypeSeries, tagTypeBlog, tagTypeContributor) match {

--- a/src/test/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilderSpec.scala
+++ b/src/test/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilderSpec.scala
@@ -27,7 +27,7 @@ class ContentAlertPayloadBuilderSpec extends MockitoSugar with WordSpecLike with
   val seriesTag = Tag("idSeries", TagType.Series, None, None, "Rugby World Cup", "", "")
   val seriesTag2 = Tag("idSeries2", TagType.Series, None, None, "Tetris World Cup", "", "")
   val blogTag = Tag("idBlog", TagType.Blog, None, None, "blogTag", "", "")
-  val blogTagOpinion = Tag("idBlog", TagType.Blog, Some("commentisfree"), None, "blogTag", "", "")
+  val blogTagOpinion = Tag("commentisfree/commentisfree", TagType.Blog, None, None, "Opinion", "", "")
   val blogTag2 = Tag("idBlog2", TagType.Blog, None, None, "blogTag2", "", "")
 
   val contributorTopic = Topic(TagContributor, "idContributor")
@@ -36,6 +36,7 @@ class ContentAlertPayloadBuilderSpec extends MockitoSugar with WordSpecLike with
   val seriesTopic2 = Topic(TagSeries, "idSeries2")
   val blogTopic = Topic(TagBlog, "idBlog")
   val blogTopic1 = Topic(TagBlog, "idBlog1")
+  val blogTopicOpinion = Topic(TagBlog, "commentisfree/commentisfree")
 
   val contentElements = Some(List(
     Element(id = "", relation = "ignore me", `type` = ElementType.Image, assets = Nil),
@@ -50,7 +51,7 @@ class ContentAlertPayloadBuilderSpec extends MockitoSugar with WordSpecLike with
     ))
   ))
 
-  val allTopics = List(contributorTopic, contributorTopic2, blogTopic, blogTopic1, seriesTopic, seriesTopic2)
+  val allTopics = List(contributorTopic, contributorTopic2, blogTopicOpinion, blogTopic, blogTopic1, seriesTopic, seriesTopic2)
   val link = GuardianLinkDetails("newId", Some("http://gu.com/p/1234"), "webTitle", Some(thumb), GITContent)
 
   private val contentFields = ContentFields(shortUrl = Some("http://gu.com/p/1234"), thumbnail = Some("thumb.jpg"), headline = Some("headline"))

--- a/src/test/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilderSpec.scala
+++ b/src/test/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilderSpec.scala
@@ -27,6 +27,7 @@ class ContentAlertPayloadBuilderSpec extends MockitoSugar with WordSpecLike with
   val seriesTag = Tag("idSeries", TagType.Series, None, None, "Rugby World Cup", "", "")
   val seriesTag2 = Tag("idSeries2", TagType.Series, None, None, "Tetris World Cup", "", "")
   val blogTag = Tag("idBlog", TagType.Blog, None, None, "blogTag", "", "")
+  val blogTagOpinion = Tag("idBlog", TagType.Blog, Some("commentisfree"), None, "blogTag", "", "")
   val blogTag2 = Tag("idBlog2", TagType.Blog, None, None, "blogTag2", "", "")
 
   val contributorTopic = Topic(TagContributor, "idContributor")
@@ -99,8 +100,8 @@ class ContentAlertPayloadBuilderSpec extends MockitoSugar with WordSpecLike with
       verifyContentAlert(tags = List(contributorTag, blogTag, seriesTag, keywordTag), expectedReason = Some(seriesTag.webTitle))
     }
 
-    "not use series tags in web title if there is more than one" in {
-      verifyContentAlert(tags = List(contributorTag, blogTag, seriesTag, keywordTag, seriesTag2), expectedReason = Some(blogTag.webTitle))
+    "use contributor name when a blog tag has the commentisfree id" in {
+      verifyContentAlert(tags = List(contributorTag, blogTagOpinion), expectedReason = Some(contributorTag.webTitle))
     }
 
     "content tag should take precedence over contributor when generating web title" in {


### PR DESCRIPTION
Make sure when the tag type has a `sectionId` of `commentisfree` show the contributor name in the notification title rather than `Opinion`