### PR TITLE
update libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ resolvers ++= Seq(
 )
 
 assemblyMergeStrategy in assembly := {
+  case "META-INF/MANIFEST.MF" => MergeStrategy.discard
   case _ => MergeStrategy.first
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -28,13 +28,13 @@ assemblyMergeStrategy in assembly := {
     oldStrategy(x)
 }
 
-val awsSdkVersion = "1.11.156"
+val awsSdkVersion = "1.11.772"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
   "com.amazonaws" % "amazon-kinesis-client" % "1.7.6",
-  "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
-  "com.amazonaws" % "aws-lambda-java-events" % "1.3.0",
+  "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",
+  "com.amazonaws" % "aws-lambda-java-events" % "2.2.8",
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
   "com.gu" %% "content-api-client-default" % "14.3",
@@ -42,15 +42,15 @@ libraryDependencies ++= Seq(
   "com.gu" %% "thrift-serializer" % "4.0.0",
   "org.joda" % "joda-convert" % "1.8.1",
   "org.jsoup" % "jsoup" % "1.8.3",
-  "com.typesafe.play" %% "play-json" % "2.6.9",
+  "com.typesafe.play" %% "play-json" % "2.8.1",
   "org.slf4j" % "slf4j-simple" % "1.7.25",
   "com.typesafe.akka" %% "akka-actor" % "2.5.2",
-  "com.squareup.okhttp3" % "okhttp" % "3.8.1",
-  "com.gu" %% "simple-configuration-ssm" % "1.4.1",
+  "com.squareup.okhttp3" % "okhttp" % "3.14.8",
+  "com.gu" %% "simple-configuration-ssm" % "1.5.2",
   "org.scalatest" %% "scalatest" % "3.0.0" % "test",
   "org.mockito" % "mockito-all" % "1.9.0" % "test",
-  "org.specs2" %% "specs2-core" % "3.9.1" % "test",
-  "org.specs2" %% "specs2-matcher-extra" % "3.9.1" % "test"
+  "org.specs2" %% "specs2-core" % "4.5.1" % "test",
+  "org.specs2" %% "specs2-matcher-extra" % "4.5.1" % "test"
 )
 
 enablePlugins(RiffRaffArtifact)

--- a/build.sbt
+++ b/build.sbt
@@ -22,10 +22,7 @@ resolvers ++= Seq(
 )
 
 assemblyMergeStrategy in assembly := {
-  case "shared.thrift" => MergeStrategy.first
-  case x =>
-    val oldStrategy = (assemblyMergeStrategy in assembly).value
-    oldStrategy(x)
+  case _ => MergeStrategy.first
 }
 
 val awsSdkVersion = "1.11.772"


### PR DESCRIPTION
First step in migrating this repo over to `mobile-n10n`
@frankie297 have you tested this repo before?

TODO in following PRs:
- Migrate over to `mobile-n10n`
- Update scala to `2.13.2`
- Replace `mobile-notifications-api-models` with `api-models` in `mobile-n10n`
- Update `content-api-client-default` to `15.9`
- Archive this repo