### PR TITLE
Avoid OOM errors

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -121,7 +121,7 @@ Resources:
           Stage: !Sub ${Stage}
       Description: Lambda to send notification when new content is published
       Handler: com.gu.mobile.content.notifications.ContentLambda::handler
-      MemorySize: 1024
+      MemorySize: 4096
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
       Timeout: 60
@@ -150,7 +150,7 @@ Resources:
           Stage: !Sub ${Stage}
       Description: Lambda that sends push notifications when new key events are published on a liveblog
       Handler: com.gu.mobile.content.notifications.LiveBlogLambda::handler
-      MemorySize: 1024
+      MemorySize: 4096
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
       Timeout: 60

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -133,6 +133,7 @@ Resources:
       Enabled: true
       EventSourceArn: !Sub arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${KinesisStreamName}-${Stage}
       StartingPosition: LATEST
+      BisectBatchOnFunctionError: true
 
   LiveBlogLambda:
     Type: AWS::Lambda::Function
@@ -162,3 +163,4 @@ Resources:
       Enabled: true
       EventSourceArn: !Sub arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${KinesisStreamName}-${Stage}
       StartingPosition: LATEST
+      BisectBatchOnFunctionError: true


### PR DESCRIPTION
We noticed a spike in the following error in the logs recently:

```Java heap space: java.lang.OutOfMemoryError java.lang.OutOfMemoryError: Java heap space```

To work around this problem this PR:

1. Allocates more memory to the lambda function(s).
1. Enables [BisectBatchOnFunctionError](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-bisectbatchonfunctionerror). This should increase the likelihood of a successful retry if an OOM occurs again.
