### PR TITLE
Update simple-config version, migrate to use maven not bintray

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,10 +45,11 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor" % "2.5.24",
   "com.squareup.okhttp3" % "okhttp" % "3.14.8",
   "com.gu" %% "simple-configuration-ssm" % "1.5.6",
-  "org.scalatest" %% "scalatest" % "3.0.8" % "test",
-  "org.mockito" % "mockito-all" % "1.9.0" % "test",
-  "org.specs2" %% "specs2-core" % "4.5.1" % "test",
-  "org.specs2" %% "specs2-matcher-extra" % "4.5.1" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.8" % Test,
+  "org.mockito" % "mockito-all" % "1.9.0" % Test,
+  "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % Test,
+  "org.specs2" %% "specs2-core" % "4.5.1" % Test,
+  "org.specs2" %% "specs2-matcher-extra" % "4.5.1" % Test
 )
 
 enablePlugins(RiffRaffArtifact)

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ description:= "lambda to replace the content-notifications-service"
 
 version := "1.0"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.5"
 
 scalacOptions ++= Seq(
   "-deprecation",
@@ -35,17 +35,17 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-events" % "2.2.8",
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
-  "com.gu" %% "content-api-client-default" % "14.3",
-  "com.gu" %% "mobile-notifications-api-models" % "1.0.3",
-  "com.gu" %% "thrift-serializer" % "4.0.0",
+  "com.gu" %% "content-api-client-default" % "17.21",
+  "com.gu" %% "mobile-notifications-api-models" % "1.0.14",
+  "com.gu" %% "thrift-serializer" % "4.0.2",
   "org.joda" % "joda-convert" % "1.8.1",
   "org.jsoup" % "jsoup" % "1.8.3",
   "com.typesafe.play" %% "play-json" % "2.8.1",
   "org.slf4j" % "slf4j-simple" % "1.7.25",
-  "com.typesafe.akka" %% "akka-actor" % "2.5.2",
+  "com.typesafe.akka" %% "akka-actor" % "2.5.24",
   "com.squareup.okhttp3" % "okhttp" % "3.14.8",
   "com.gu" %% "simple-configuration-ssm" % "1.5.6",
-  "org.scalatest" %% "scalatest" % "3.0.0" % "test",
+  "org.scalatest" %% "scalatest" % "3.0.8" % "test",
   "org.mockito" % "mockito-all" % "1.9.0" % "test",
   "org.specs2" %% "specs2-core" % "4.5.1" % "test",
   "org.specs2" %% "specs2-matcher-extra" % "4.5.1" % "test"

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ val awsSdkVersion = "1.11.772"
 libraryDependencies ++= Seq(
   "software.amazon.awssdk" % "sts" % "2.17.109",
   "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
-  "com.amazonaws" % "amazon-kinesis-client" % "1.7.6",
+  "com.amazonaws" % "amazon-kinesis-client" % "1.14.8",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",
   "com.amazonaws" % "aws-lambda-java-events" % "2.2.8",
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -16,9 +16,8 @@ scalacOptions ++= Seq(
 )
 
 resolvers ++= Seq(
-   Resolver.sonatypeRepo("releases"),
-  "Guardian Mobile Bintray" at "https://dl.bintray.com/guardian/mobile",
-  "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
+  "Guardian GitHub Releases" at "https://guardian.github.com/maven/repo-releases",
+  "Guardian GitHub Snapshots" at "https://guardian.github.com/maven/repo-snapshots"
 )
 
 assemblyMergeStrategy in assembly := {
@@ -29,6 +28,7 @@ assemblyMergeStrategy in assembly := {
 val awsSdkVersion = "1.11.772"
 
 libraryDependencies ++= Seq(
+  "software.amazon.awssdk" % "sts" % "2.17.109",
   "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
   "com.amazonaws" % "amazon-kinesis-client" % "1.7.6",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-simple" % "1.7.25",
   "com.typesafe.akka" %% "akka-actor" % "2.5.2",
   "com.squareup.okhttp3" % "okhttp" % "3.14.8",
-  "com.gu" %% "simple-configuration-ssm" % "1.5.2",
+  "com.gu" %% "simple-configuration-ssm" % "1.5.6",
   "org.scalatest" %% "scalatest" % "3.0.0" % "test",
   "org.mockito" % "mockito-all" % "1.9.0" % "test",
   "org.specs2" %% "specs2-core" % "4.5.1" % "test",

--- a/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
@@ -11,7 +11,7 @@ import com.gu.crier.model.event.v1.{ EventPayload, RetrievableContent, _ }
 import com.gu.mobile.content.notifications.lib.{ ContentAlertPayloadBuilder, MessageSender, NotificationsApiClient, NotificationsDynamoDb }
 import com.gu.mobile.content.notifications.metrics.CloudWatchMetrics
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.{ ExecutionContext, Future }
 
 sealed trait CapiResponse
@@ -36,9 +36,9 @@ trait Lambda extends Logging {
 
   def handler(event: KinesisEvent) {
     val rawRecord: List[Record] = event.getRecords.asScala.map(_.getKinesis).toList
-    val userRecords = UserRecord.deaggregate(rawRecord.asJava)
+    val userRecords: List[UserRecord] = UserRecord.deaggregate(rawRecord.asJava).asScala.toList
 
-    CapiEventProcessor.process(userRecords.asScala) { event =>
+    CapiEventProcessor.process(userRecords) { event =>
       event.eventType match {
         case EventType.Update =>
           event.payload.map {

--- a/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
@@ -34,7 +34,7 @@ trait Lambda extends Logging {
 
   implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
-  def handler(event: KinesisEvent) {
+  def handler(event: KinesisEvent): Unit = {
     val rawRecord: List[Record] = event.getRecords.asScala.map(_.getKinesis).toList
     val userRecords: List[UserRecord] = UserRecord.deaggregate(rawRecord.asJava).asScala.toList
 

--- a/src/main/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilder.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilder.scala
@@ -27,10 +27,10 @@ trait ContentAlertPayloadBuilder extends Logging {
   private val followableTopicTypes: Set[TagType] = Set(TagType.Series, TagType.Blog, TagType.Contributor)
 
   def buildPayLoad(content: Content): ContentAlertPayload = {
-    val tagTypeSeries: Option[Tag] = content.tags.findOne(_.`type` == TagType.Series)
+    val tagTypeSeries: Option[Tag] = content.tags.find(_.`type` == TagType.Series)
     val tagTypeBlog: Option[Tag] = content.tags
       .filterNot(tag => tag.id.contains("commentisfree/commentisfree"))
-      .findOne(_.`type` == TagType.Blog)
+      .find(_.`type` == TagType.Blog)
     val tagTypeContributor: List[Tag] = content.tags.filter(_.`type` == TagType.Contributor).toList
 
     val followableTag: List[Tag] = (tagTypeSeries, tagTypeBlog, tagTypeContributor) match {
@@ -60,7 +60,7 @@ trait ContentAlertPayloadBuilder extends Logging {
   }
 
   def buildPayLoad(content: Content, keyEvent: KeyEvent): ContentAlertPayload = {
-    val seriesTag: Option[Tag] = content.tags.findOne(_.`type` == TagType.Series)
+    val seriesTag: Option[Tag] = content.tags.find(_.`type` == TagType.Series)
     val title: String = seriesTag.map(tag => s"Update: ${tag.webTitle}").getOrElse("Liveblog Update")
     ContentAlertPayload(
       title = Some(title),

--- a/src/main/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilder.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilder.scala
@@ -96,7 +96,7 @@ trait ContentAlertPayloadBuilder extends Logging {
 
   private def selectMainImage(content: Content, minWidth: Int): Option[String] = {
     def width(asset: Asset): Int = asset.assetWidth.flatMap { aw => Try(aw.toInt).toOption }.getOrElse(0)
-    def sortedAssets(element: Element): Seq[Asset] = element.assets.sortBy(width)
+    def sortedAssets(element: Element): Seq[Asset] = element.assets.sortBy(width).toSeq
 
     val elements = content.elements.getOrElse(Nil)
     val mainImage = elements.find {

--- a/src/main/scala/com/gu/mobile/content/notifications/lib/ContentApi.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/lib/ContentApi.scala
@@ -25,7 +25,7 @@ object ContentApi {
     }
 
     private val followableTagTypes: Set[TagType] = Set(TagType.Series, TagType.Blog, TagType.Contributor)
-    def followableTags: Seq[Tag] = content.tags.filter(tag => followableTagTypes.contains(tag.`type`))
+    def followableTags: Seq[Tag] = content.tags.filter(tag => followableTagTypes.contains(tag.`type`)).toSeq
     def isLive: Boolean = content.fields.flatMap(f => f.liveBloggingNow).getOrElse(false) && content.tags.map(_.id).toList.exists(_ == "tone/minutebyminute")
 
     def getLoggablePublicationDate: String = {

--- a/src/main/scala/com/gu/mobile/content/notifications/lib/MessageSender.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/lib/MessageSender.scala
@@ -35,10 +35,10 @@ class MessageSender(config: Configuration, apiClient: NotificationsApiClient, pa
       apiClient.send(notification) match {
         case Right(id) =>
           logger.info(s"Successfully sent notification $id for : ${notification.title}")
-          metrics.send(MetricDataPoint(name = "SendNotificationLatency", value = duration, unit = StandardUnit.Milliseconds))
+          metrics.send(MetricDataPoint(name = "SendNotificationLatency", value = duration.toDouble, unit = StandardUnit.Milliseconds))
         case Left(error) =>
           logger.error(s"Error sending notification: $notification. error: $error")
-          metrics.send(MetricDataPoint(name = "SendNotificationErrorLatency", value = duration, unit = StandardUnit.Milliseconds))
+          metrics.send(MetricDataPoint(name = "SendNotificationErrorLatency", value = duration.toDouble, unit = StandardUnit.Milliseconds))
       }
     }
   }

--- a/src/main/scala/com/gu/mobile/content/notifications/lib/MessageSender.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/lib/MessageSender.scala
@@ -25,7 +25,7 @@ class MessageSender(config: Configuration, apiClient: NotificationsApiClient, pa
 
   }
 
-  private def sendNotification(notification: ContentAlertPayload) {
+  private def sendNotification(notification: ContentAlertPayload): Unit = {
 
     val start = System.currentTimeMillis()
     lazy val duration = System.currentTimeMillis() - start

--- a/src/main/scala/com/gu/mobile/content/notifications/lib/NotificationsDynamoDb.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/lib/NotificationsDynamoDb.scala
@@ -16,7 +16,7 @@ class NotificationsDynamoDb(dynamoDB: DynamoDB, config: Configuration) {
 
   def saveContentItem(contentId: String): Unit = {
     val expiry = DateTime.now().plusDays(1).getMillis / 1000 //Expiry should be an epoch value: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/time-to-live-ttl-how-to.html
-    contentTable.putItem(new Item().withPrimaryKey("contentId", contentId).withDouble("expiry", expiry))
+    contentTable.putItem(new Item().withPrimaryKey("contentId", contentId).withDouble("expiry", expiry.toDouble))
   }
 
   def haveSeenContentItem(contentId: String): Boolean = {
@@ -31,7 +31,7 @@ class NotificationsDynamoDb(dynamoDB: DynamoDB, config: Configuration) {
 
   def saveLiveBlogEvent(contentId: String, blockId: String) = {
     val expiry = DateTime.now().plusDays(1).getMillis / 1000
-    liveBlogTable.putItem(new Item().withPrimaryKey("contentId", contentId, "blockId", blockId).withDouble("expiry", expiry))
+    liveBlogTable.putItem(new Item().withPrimaryKey("contentId", contentId, "blockId", blockId).withDouble("expiry", expiry.toDouble))
   }
 }
 

--- a/src/main/scala/com/gu/mobile/content/notifications/lib/NotificationsDynamoDb.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/lib/NotificationsDynamoDb.scala
@@ -1,7 +1,7 @@
 package com.gu.mobile.content.notifications.lib
 
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{ AWSCredentialsProviderChain, STSAssumeRoleSessionCredentialsProvider }
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
 import com.amazonaws.services.dynamodbv2.document.spec.GetItemSpec

--- a/src/main/scala/com/gu/mobile/content/notifications/metrics/Metrics.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/metrics/Metrics.scala
@@ -9,7 +9,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 trait Metrics {
-  def send(mdp: MetricDataPoint)
+  def send(mdp: MetricDataPoint): Unit
   def executionContext: ExecutionContext
 }
 

--- a/src/main/scala/com/gu/mobile/content/notifications/metrics/MetricsActor.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/metrics/MetricsActor.scala
@@ -5,7 +5,7 @@ import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.amazonaws.services.cloudwatch.model._
 import com.gu.mobile.content.notifications.{ Configuration, Logging }
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class MetricsActor(val cloudWatch: AmazonCloudWatch, config: Configuration) extends Actor with MetricActorLogic {
 

--- a/src/test/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilderSpec.scala
+++ b/src/test/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilderSpec.scala
@@ -1,15 +1,14 @@
 package com.gu.mobile.content.notifications.lib
 
 import java.net.URI
-
 import com.gu.contentapi.client.model.v1._
 import com.gu.mobile.content.notifications.Configuration
 import com.gu.mobile.content.notifications.model.KeyEvent
 import com.gu.mobile.notifications.client.models.TopicTypes.{ TagBlog, TagContributor, TagKeyword, TagSeries }
 import com.gu.mobile.notifications.client.models._
 import org.joda.time.{ DateTime, LocalDate }
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ MustMatchers, WordSpecLike }
+import org.scalatestplus.mockito.MockitoSugar
 
 class ContentAlertPayloadBuilderSpec extends MockitoSugar with WordSpecLike with MustMatchers {
 

--- a/src/test/scala/com/gu/mobile/content/notifications/lib/MessageSenderSpec.scala
+++ b/src/test/scala/com/gu/mobile/content/notifications/lib/MessageSenderSpec.scala
@@ -2,21 +2,20 @@ package com.gu.mobile.content.notifications.lib
 
 import com.amazonaws.services.kinesis.model.Record
 import com.gu.contentapi.client.model.v1.Content
-import com.gu.crier.model.event.v1.{ Event, EventPayload, EventType, ItemType, RetrievableContent }
-import com.gu.mobile.content.notifications.{ CapiEventProcessor, Configuration }
+import com.gu.crier.model.event.v1._
 import com.gu.mobile.content.notifications.metrics.{ MetricDataPoint, Metrics }
+import com.gu.mobile.content.notifications.{ CapiEventProcessor, Configuration }
 import com.gu.mobile.notifications.client.models.ContentAlertPayload
 import com.gu.thrift.serializer._
-import java.nio.ByteBuffer
-import java.util.UUID
-
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually._
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{ BeforeAndAfterEach, MustMatchers, OneInstancePerTest, WordSpecLike, Matchers => ShouldMatchers }
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ BeforeAndAfterEach, MustMatchers, OneInstancePerTest, WordSpecLike, Matchers => ShouldMatchers }
+import org.scalatestplus.mockito.MockitoSugar
 
+import java.nio.ByteBuffer
+import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 

--- a/src/test/scala/com/gu/mobile/content/notifications/metrics/MetricsActorSpec.scala
+++ b/src/test/scala/com/gu/mobile/content/notifications/metrics/MetricsActorSpec.scala
@@ -31,7 +31,7 @@ class MetricsActorSpec extends WordSpecLike with MockitoSugar with MustMatchers 
       metricData.get(0).getStatisticValues.getSampleCount mustEqual 3d
 
     }
-    "call cloudwatch once but not aggregate if two metrics are recieved " in new MetricActorScope {
+    "call cloudwatch once but not aggregate if two metrics are received " in new MetricActorScope {
       val metrics = List(
         new MetricDataPoint("test", "m1", 0d),
         new MetricDataPoint("test", "m1", 1d),
@@ -47,8 +47,8 @@ class MetricsActorSpec extends WordSpecLike with MockitoSugar with MustMatchers 
       val metricData = requestCaptor.getValue.getMetricData
 
       metricData must have size 2
-      metricData.get(0).getStatisticValues.getSampleCount mustEqual 3d
-      metricData.get(1).getStatisticValues.getSampleCount mustEqual 2d
+      metricData.get(1).getStatisticValues.getSampleCount mustEqual 3d
+      metricData.get(0).getStatisticValues.getSampleCount mustEqual 2d
     }
     "call cloudwatch once if there's more than one metric" in new MetricActorScope {
       val metrics = List(

--- a/src/test/scala/com/gu/mobile/content/notifications/metrics/MetricsActorSpec.scala
+++ b/src/test/scala/com/gu/mobile/content/notifications/metrics/MetricsActorSpec.scala
@@ -4,8 +4,8 @@ import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest
 import org.mockito.Mockito._
 import org.mockito.{ ArgumentCaptor, Matchers }
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ MustMatchers, WordSpecLike }
+import org.scalatestplus.mockito.MockitoSugar
 import org.specs2.specification.Scope
 
 class MetricsActorSpec extends WordSpecLike with MockitoSugar with MustMatchers {


### PR DESCRIPTION
## What does this change?
- Updated scala version to 2.13
- Migrated dependency resolver to Maven from Bintray
- Dependency updates
- We now rely on two different versions of AWS SDK, updated credentials provider builder to reflect that
- As part of scala upgrade, made types more explicit
- Update tests/spec files to use `org.scalatestplus.mockito.MockitoSugar`

## How can we measure success?

The builds no longer fail, they succeed and we can once again merge to main

Paired with @DavidLawes 