### PR TITLE
Add first-edition to tag list and add corresponding test

### DIFF
--- a/src/main/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilder.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilder.scala
@@ -19,6 +19,7 @@ trait ContentAlertPayloadBuilder extends Logging {
 
   private val topicsWithoutPrefix = Set(
     Topic(TagSeries, "world/series/guardian-morning-briefing"),
+    Topic(TagSeries, "world/series/first-edition"),
     Topic(TagSeries, "australia-news/series/guardian-australia-s-morning-mail"),
     Topic(TagSeries, "us-news/series/guardian-us-briefing"),
     Topic(TagSeries, "politics/series/andrew-sparrows-election-briefing")

--- a/src/test/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilderSpec.scala
+++ b/src/test/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilderSpec.scala
@@ -141,6 +141,14 @@ class ContentAlertPayloadBuilderSpec extends MockitoSugar with WordSpecLike with
       builder.buildPayLoad(contentItem) mustEqual expectedPayload
     }
 
+    "do not prefix title for first-edition" in {
+      val tag = Tag("world/series/first-edition", TagType.Series, None, None, "Steve", "", "")
+      val topic = Topic(TagSeries, "world/series/first-edition")
+      val contentItem = item.copy(tags = List(tag))
+      val expectedPayload = expectedPayloadForItem.copy(title = None, topic = List(topic))
+      builder.buildPayLoad(contentItem) mustEqual expectedPayload
+    }
+
     "do not prefix title for andrew-sparrows-election-briefing" in {
       val tag = Tag("politics/series/andrew-sparrows-election-briefing", TagType.Series, None, None, "Steve", "", "")
       val topic = Topic(TagSeries, "politics/series/andrew-sparrows-election-briefing")


### PR DESCRIPTION
## What does this change?
Adds a new First Edition series tag to the list of topics that shouldn't be prefixed. This should allow us to send published article notifications to users that have signed up to both morning-briefing topic and first-edition topic.

## How to test
In CODE publish an article that has both topic tags and see if we get the notification, repeat for articles that have just one of the tags

## How can we measure success?
We can successfully send and open a notification

## Have we considered potential risks?
The users might have signed up for both topics and receive two notifications