### PR TITLE
Bump sbt to 1.7.1 and jackson to 1.12.6.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor" % "2.5.24",
   "com.squareup.okhttp3" % "okhttp" % "3.14.8",
   "com.gu" %% "simple-configuration-ssm" % "1.5.6",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.12.6.1",
   "org.scalatest" %% "scalatest" % "3.0.8" % Test,
   "org.mockito" % "mockito-all" % "1.9.0" % Test,
   "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % Test,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=1.7.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,7 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.7")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
+
+addDependencyTreePlugin

--- a/src/main/scala/com/gu/mobile/content/notifications/Configuration.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/Configuration.scala
@@ -15,8 +15,7 @@ case class Configuration(
   crossAccountDynamoRole: String,
   contentDynamoTableName: String,
   liveBlogContentDynamoTableName: String,
-  stage: String
-)
+  stage: String)
 
 object Configuration extends Logging {
   val appName = Option(System.getenv("App")).getOrElse(sys.error("No app name set. Lambda will not rum"))
@@ -36,9 +35,7 @@ object Configuration extends Logging {
     StsAssumeRoleCredentialsProvider.builder
       .stsClient(StsClient.create)
       .refreshRequest(req)
-      .build()
-
-  )
+      .build())
 
   val conf = {
     val identity = AppIdentity.whoAmI(defaultAppName = appName)
@@ -77,8 +74,7 @@ object Configuration extends Logging {
       crossAccountDynamoRole,
       contentDynamoTableName,
       contentLiveBlogDynamoTableName,
-      stage
-    )
+      stage)
   }
 
   private def getMandatoryProperty(key: String) =

--- a/src/main/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilder.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilder.scala
@@ -22,8 +22,7 @@ trait ContentAlertPayloadBuilder extends Logging {
     Topic(TagSeries, "world/series/first-edition"),
     Topic(TagSeries, "australia-news/series/guardian-australia-s-morning-mail"),
     Topic(TagSeries, "us-news/series/guardian-us-briefing"),
-    Topic(TagSeries, "politics/series/andrew-sparrows-election-briefing")
-  )
+    Topic(TagSeries, "politics/series/andrew-sparrows-election-briefing"))
 
   private val followableTopicTypes: Set[TagType] = Set(TagType.Series, TagType.Blog, TagType.Contributor)
 
@@ -56,8 +55,7 @@ trait ContentAlertPayloadBuilder extends Logging {
       importance = Importance.Major,
       topic = topics,
       debug = false,
-      dryRun = None
-    )
+      dryRun = None)
   }
 
   def buildPayLoad(content: Content, keyEvent: KeyEvent): ContentAlertPayload = {
@@ -72,8 +70,7 @@ trait ContentAlertPayloadBuilder extends Logging {
       importance = Importance.Major,
       topic = List(Topic(TopicTypes.Content, content.id)),
       debug = false,
-      dryRun = None
-    )
+      dryRun = None)
   }
 
   private def getTopicType(tagType: TagType): Option[TopicType] = tagType match {
@@ -113,7 +110,6 @@ trait ContentAlertPayloadBuilder extends Logging {
     title = content.webTitle,
     thumbnail = content.thumbNail,
     git = GITContent,
-    blockId = keyEvent.map { b => b.blockId }
-  )
+    blockId = keyEvent.map { b => b.blockId })
 }
 

--- a/src/main/scala/com/gu/mobile/content/notifications/lib/NotificationsDynamoDb.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/lib/NotificationsDynamoDb.scala
@@ -43,8 +43,7 @@ object NotificationsDynamoDb extends Logging {
 
     val dynamoCredentialsProvider = new AWSCredentialsProviderChain(
       new ProfileCredentialsProvider(),
-      new STSAssumeRoleSessionCredentialsProvider.Builder(config.crossAccountDynamoRole, "mobile-db").build()
-    )
+      new STSAssumeRoleSessionCredentialsProvider.Builder(config.crossAccountDynamoRole, "mobile-db").build())
 
     val client = AmazonDynamoDBClientBuilder.standard()
       .withRegion(Regions.EU_WEST_1)

--- a/src/main/scala/com/gu/mobile/content/notifications/metrics/Metrics.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/metrics/Metrics.scala
@@ -30,8 +30,7 @@ class CloudWatchMetrics(config: Configuration) extends Metrics with Logging {
     initialDelay = 0.second,
     interval = 1.minute,
     receiver = metricsActor,
-    message = MetricsActor.Aggregate
-  )
+    message = MetricsActor.Aggregate)
 
   logger.debug("Actor scheduled")
 
@@ -43,11 +42,10 @@ class CloudWatchMetrics(config: Configuration) extends Metrics with Logging {
 }
 
 case class MetricDataPoint(
-    namespage: String = "mobile-notifications-lambda",
-    name: String,
-    value: Double,
-    unit: StandardUnit = StandardUnit.None
-) {
+  namespage: String = "mobile-notifications-lambda",
+  name: String,
+  value: Double,
+  unit: StandardUnit = StandardUnit.None) {
   override def toString = s"Namespace: $namespage Name: $name value: $value"
 }
 

--- a/src/test/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilderSpec.scala
+++ b/src/test/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilderSpec.scala
@@ -46,9 +46,7 @@ class ContentAlertPayloadBuilderSpec extends MockitoSugar with WordSpecLike with
       Asset(`type` = AssetType.Image, mimeType = None, file = Some("https://some.url/image500000.jpg"), typeData = Some(AssetFields(width = Some(500000)))),
       Asset(`type` = AssetType.Image, mimeType = None, file = Some("https://some.url/image1000.jpg"), typeData = Some(AssetFields(width = Some(1000)))),
       Asset(`type` = AssetType.Image, mimeType = None, file = Some("https://some.url/image749.jpg"), typeData = Some(AssetFields(width = Some(749)))),
-      Asset(`type` = AssetType.Image, mimeType = None, file = Some("https://some.url/image100.jpg"), typeData = Some(AssetFields(width = Some(100))))
-    ))
-  ))
+      Asset(`type` = AssetType.Image, mimeType = None, file = Some("https://some.url/image100.jpg"), typeData = Some(AssetFields(width = Some(100))))))))
 
   val allTopics = List(contributorTopic, contributorTopic2, blogTopicOpinion, blogTopic, blogTopic1, seriesTopic, seriesTopic2)
   val link = GuardianLinkDetails("newId", Some("http://gu.com/p/1234"), "webTitle", Some(thumb), GITContent)
@@ -66,8 +64,7 @@ class ContentAlertPayloadBuilderSpec extends MockitoSugar with WordSpecLike with
     tags = List(seriesTag),
     elements = None,
     references = Nil,
-    isExpired = None
-  )
+    isExpired = None)
 
   val expectedPayloadForItem = ContentAlertPayload(
     title = Some(TagContributor.toString),
@@ -78,8 +75,7 @@ class ContentAlertPayloadBuilderSpec extends MockitoSugar with WordSpecLike with
     importance = Importance.Major,
     topic = List(seriesTopic),
     debug = false,
-    dryRun = None
-  )
+    dryRun = None)
 
   val keyEvent = KeyEvent("blockId", Some("blogPostTitle"), "body", Option(DateTime.now()), Option(DateTime.now()))
 
@@ -87,8 +83,7 @@ class ContentAlertPayloadBuilderSpec extends MockitoSugar with WordSpecLike with
     title = Some(s"Update: ${seriesTag.webTitle}"),
     topic = List(Topic(TopicTypes.Content, "newId")),
     message = Some("blogPostTitle"),
-    link = link.copy(blockId = Some("blockId"))
-  )
+    link = link.copy(blockId = Some("blockId")))
 
   "Content Alert Payload Builder" must {
 

--- a/src/test/scala/com/gu/mobile/content/notifications/lib/MessageSenderSpec.scala
+++ b/src/test/scala/com/gu/mobile/content/notifications/lib/MessageSenderSpec.scala
@@ -65,9 +65,7 @@ class MessageSenderSpec extends MockitoSugar with WordSpecLike with MustMatchers
         id = "0987654321",
         capiUrl = "http://www.theguardian.com/",
         lastModifiedDate = Some(8888888888L),
-        internalRevision = Some(444444)
-      )))
-    )
+        internalRevision = Some(444444)))))
 
     "properly deserialize a compressed event" in {
       val bytes = ThriftSerializer.serializeToBytes(event, Some(ZstdType), None)

--- a/src/test/scala/com/gu/mobile/content/notifications/metrics/MetricsActorSpec.scala
+++ b/src/test/scala/com/gu/mobile/content/notifications/metrics/MetricsActorSpec.scala
@@ -19,8 +19,7 @@ class MetricsActorSpec extends WordSpecLike with MockitoSugar with MustMatchers 
       val metrics = List(
         new MetricDataPoint("test", "m1", 0d),
         new MetricDataPoint("test", "m1", 1d),
-        new MetricDataPoint("test", "m1", 2d)
-      )
+        new MetricDataPoint("test", "m1", 2d))
 
       actorLogic.aggregatePoint(metrics)
       val requestCaptor = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
@@ -37,8 +36,7 @@ class MetricsActorSpec extends WordSpecLike with MockitoSugar with MustMatchers 
         new MetricDataPoint("test", "m1", 1d),
         new MetricDataPoint("test", "m1", 2d),
         new MetricDataPoint("test", "m2", 5d),
-        new MetricDataPoint("test", "m2", 6d)
-      )
+        new MetricDataPoint("test", "m2", 6d))
 
       actorLogic.aggregatePoint(metrics)
       val requestCaptor = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
@@ -54,8 +52,7 @@ class MetricsActorSpec extends WordSpecLike with MockitoSugar with MustMatchers 
       val metrics = List(
         MetricDataPoint("test", "m1", 0d),
         MetricDataPoint("test", "m2", 1d),
-        MetricDataPoint("test", "m3", 2d)
-      )
+        MetricDataPoint("test", "m3", 2d))
       actorLogic.aggregatePoint(metrics)
       verify(mockCloudWatch, times(1)).putMetricData(Matchers.any[PutMetricDataRequest])
     }
@@ -63,8 +60,7 @@ class MetricsActorSpec extends WordSpecLike with MockitoSugar with MustMatchers 
       val metrics = List(
         MetricDataPoint("namespace1", "m1", 0d),
         MetricDataPoint("namespace2", "m2", 1d),
-        MetricDataPoint("namespace2", "m1", 2d)
-      )
+        MetricDataPoint("namespace2", "m1", 2d))
       actorLogic.aggregatePoint(metrics)
       verify(mockCloudWatch, times(2)).putMetricData(Matchers.any[PutMetricDataRequest])
     }
@@ -72,8 +68,7 @@ class MetricsActorSpec extends WordSpecLike with MockitoSugar with MustMatchers 
       val metrics = List(
         MetricDataPoint("namespace1", "m1", 0d),
         MetricDataPoint("namespace1", "m1", 1d),
-        MetricDataPoint("namespace1", "m1", 2d)
-      )
+        MetricDataPoint("namespace1", "m1", 2d))
       actorLogic.aggregatePoint(metrics)
       val requestCaptor = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
       verify(mockCloudWatch, times(1)).putMetricData(requestCaptor.capture())


### PR DESCRIPTION
## What does this change?

This PR bumps the sbt to 1.7.1 and the jackson databind library to 1.12.6.1 to fix snyk vulnerability.

## How to test

All unit tests passed.  Snyk local test confirms the vulnerability has been fixed.

