### PR TITLE
Introduce protobuf-java as a direct dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,6 +47,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "simple-configuration-ssm" % "1.5.6",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.4",
   "com.squareup.okhttp3" % "okhttp" % "4.10.0",
+  "com.google.protobuf" % "protobuf-java" % "3.19.6",
   "org.scalatest" %% "scalatest" % "3.0.8" % Test,
   "org.mockito" % "mockito-all" % "1.9.0" % Test,
   "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % Test,


### PR DESCRIPTION
## What does this change?

Introduces protobuf-java as a direct dependency in order to fix a snyk vulnerability.