### PR TITLE
Migrated TC pipeline to GHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+name: build
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions: # required by aws-actions/configure-aws-credentials
+      id-token: write
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions/setup-java@v3
+      with:
+        distribution: 'corretto'
+        java-version: '8'
+        cache: 'sbt'
+
+    - name: Build and Test project, Assemble jar, copy to root dir
+      run: |
+        sbt compile test assembly
+        cp target/scala*/mobile-notifications-content.jar .
+
+    - name: AWS Auth
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+        aws-region: eu-west-1
+
+    - name: Upload to riff-raff
+      uses: guardian/actions-riff-raff@v2
+      with:
+        configPath: riff-raff.yaml
+        projectName: Mobile::mobile-notifications-content
+        buildNumberOffset: 468
+        contentDirectories: |
+          mobile-notifications-content:
+          - mobile-notifications-content.jar
+          mobile-notifications-content:
+          - cfn.yaml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
     permissions: # required by aws-actions/configure-aws-credentials
       id-token: write
       contents: read
+      checks: write
 
     steps:
     - uses: actions/checkout@v3
@@ -49,7 +50,7 @@ jobs:
       with:
         configPath: riff-raff.yaml
         projectName: Mobile::mobile-notifications-content
-        buildNumberOffset: 468
+        buildNumberOffset: 467
         contentDirectories: |
           mobile-notifications-content:
           - mobile-notifications-content.jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,16 @@ jobs:
         sbt compile test assembly
         cp target/scala*/mobile-notifications-content.jar .
 
+    - name: Test Report
+      uses: dorny/test-reporter@v1
+      if: success() || failure()    # run this step even if previous step failed
+      with:
+        name: Tests
+        path: target/test-reports/TEST-*.xml
+        reporter: java-junit
+        only-summary: 'false'
+        fail-on-error: 'true'
+
     - name: AWS Auth
       uses: aws-actions/configure-aws-credentials@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,9 +50,9 @@ jobs:
       with:
         configPath: riff-raff.yaml
         projectName: Mobile::mobile-notifications-content
-        buildNumberOffset: 467
+        buildNumberOffset: 466
         contentDirectories: |
           mobile-notifications-content:
           - mobile-notifications-content.jar
-          mobile-notifications-content:
+          mobile-notifications-content-cfn:
           - cfn.yaml

--- a/build.sbt
+++ b/build.sbt
@@ -56,11 +56,4 @@ libraryDependencies ++= Seq(
 )
 libraryDependencies += "com.github.luben" % "zstd-jni" % "1.5.5-3"
 
-enablePlugins(RiffRaffArtifact)
-
 assemblyJarName := s"${name.value}.jar"
-riffRaffPackageType := assembly.value
-riffRaffUploadArtifactBucket := Option("riffraff-artifact")
-riffRaffUploadManifestBucket := Option("riffraff-builds")
-riffRaffManifestProjectName := s"Mobile::${name.value}"
-riffRaffArtifactResources += (file("cfn.yaml"), s"${name.value}-cfn/cfn.yaml")

--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,7 @@ libraryDependencies ++= Seq(
   "org.specs2" %% "specs2-core" % "4.5.1" % Test,
   "org.specs2" %% "specs2-matcher-extra" % "4.5.1" % Test
 )
+libraryDependencies += "com.github.luben" % "zstd-jni" % "1.5.5-3"
 
 enablePlugins(RiffRaffArtifact)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,5 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
-
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")


### PR DESCRIPTION
## What does this change?

Just migrates the pipeline from here:
https://teamcity.gutools.co.uk/buildConfiguration/Mobile_MobileNotificationsContent2?buildTypeTab=overview&mode=builds#all-projects

An error message was saying:

```bash
java.lang.UnsatisfiedLinkError: no zstd-jni in java.library.path
```

So searching and following docs, I added the dependency explicitly, and the tests pass.

## How to test

Deploy via riff-raff, there should be no change required.