### PR TITLE
Java 11 runtime and build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/setup-java@v3
       with:
         distribution: 'corretto'
-        java-version: '8'
+        java-version: '11'
         cache: 'sbt'
 
     - name: Build and Test project, Assemble jar, copy to root dir

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,6 @@ scalaVersion := "2.13.5"
 scalacOptions ++= Seq(
   "-deprecation",
   "-encoding", "UTF-8",
-  "-target:jvm-1.8",
   "-Ywarn-dead-code"
 )
 

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -123,7 +123,7 @@ Resources:
       Handler: com.gu.mobile.content.notifications.ContentLambda::handler
       MemorySize: 4096
       Role: !GetAtt ExecutionRole.Arn
-      Runtime: java8
+      Runtime: java11
       Timeout: 60
 
   ContentEventSource:
@@ -153,7 +153,7 @@ Resources:
       Handler: com.gu.mobile.content.notifications.LiveBlogLambda::handler
       MemorySize: 4096
       Role: !GetAtt ExecutionRole.Arn
-      Runtime: java8
+      Runtime: java11
       Timeout: 60
 
   LiveBlogEventSource:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Java 8 runtime is out of support.
Level to Java 11 runtime in CloudFormation which is generally harmless.

Nudge the Github build to Java 11. 
Remove explicit targeting of Java 8 to celebrate Scala 2.13's embrace of recent JDKs.
Emphasis that Java 8 is no longer required on dev machines to work with these Lambdas.


## How to test

Run in CODE.
Level the Runtime with existing binary.
Check.
Then redeploy and check the Java 11 built binary also runs.
Adjust memory if Java 11 has head room problems.


## How can we measure success?

No end user impact.
Removes last Java 8 runtimes from Content account.
AWS does not nag us about these Lambdas until 2026.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
