### PR TITLE
DRAFT: send messages to mobile account

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-8.342.07.3

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-events" % "2.2.8",
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
+  "com.amazonaws" % "aws-java-sdk-sqs" % awsSdkVersion,
   "com.gu" %% "content-api-client-default" % "19.0.4",
   "com.gu" %% "mobile-notifications-api-models" % "1.0.15",
   "com.gu" %% "thrift-serializer" % "4.0.3",

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -39,6 +39,7 @@ Parameters:
 Resources:
   ExecutionRole:
     Type: AWS::IAM::Role
+    RoleName: !Sub mobile-notifications-content-lambdas-role-${Stage}
     Properties:
       AssumeRolePolicyDocument:
         Statement:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -39,8 +39,8 @@ Parameters:
 Resources:
   ExecutionRole:
     Type: AWS::IAM::Role
-    RoleName: !Sub mobile-notifications-content-lambdas-role-${Stage}
     Properties:
+      RoleName: !Sub mobile-notifications-content-lambdas-role-${Stage}
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -67,7 +67,7 @@ Resources:
             Statement:
               Effect: Allow
               Action: sts:AssumeRole
-              Resource: !Sub arn:aws:iam::${MobileAccountId}:role/${CrossAccountBaseRoleName}2-sqs-${Stage}
+              Resource: !Sub arn:aws:iam::${MobileAccountId}:role/${CrossAccountBaseRoleName}-sqs-${Stage}
         - PolicyName: logs
           PolicyDocument:
             Statement:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -61,6 +61,12 @@ Resources:
               Effect: Allow
               Action: sts:AssumeRole
               Resource: !Sub arn:aws:iam::${MobileAccountId}:role/${CrossAccountBaseRoleName}-dynamo-${Stage}
+        - PolicyName: assume-mobile-sqs-role
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action: sts:AssumeRole
+              Resource: !Sub arn:aws:iam::${MobileAccountId}:role/${CrossAccountBaseRoleName}-sqs-${Stage}
         - PolicyName: logs
           PolicyDocument:
             Statement:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -66,7 +66,7 @@ Resources:
             Statement:
               Effect: Allow
               Action: sts:AssumeRole
-              Resource: !Sub arn:aws:iam::${MobileAccountId}:role/${CrossAccountBaseRoleName}-sqs-${Stage}
+              Resource: !Sub arn:aws:iam::${MobileAccountId}:role/${CrossAccountBaseRoleName}2-sqs-${Stage}
         - PolicyName: logs
           PolicyDocument:
             Statement:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -40,7 +40,7 @@ Resources:
   ExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub mobile-notifications-content-lambdas-role-${Stage}
+      RoleName: !Sub mobile-notifications-content-lambda-role-${Stage}
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow

--- a/src/main/scala/com/gu/mobile/content/notifications/Configuration.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/Configuration.scala
@@ -15,6 +15,8 @@ case class Configuration(
   crossAccountDynamoRole: String,
   contentDynamoTableName: String,
   liveBlogContentDynamoTableName: String,
+  crossAccountSqsRole: String,
+  sqsQueue: String,
   stage: String)
 
 object Configuration extends Logging {
@@ -66,6 +68,12 @@ object Configuration extends Logging {
     val contentLiveBlogDynamoTableName = getMandatoryProperty("content.liveblog-notifications.table")
     logger.info(s"mobile-liveblog-content-notifications $contentLiveBlogDynamoTableName")
 
+    val crossAccountSqsRole = getMandatoryProperty("content.notifications.crossAccountSqsRole")
+    logger.info(s"content.notifications.crossAccountSqsRole $crossAccountSqsRole")
+
+    val crossAccountSqs = getMandatoryProperty("content.notifications.crossAccountSqs")
+    logger.info(s"content.notifications.crossAccountSqs $crossAccountSqs")
+
     Configuration(
       guardianNotificationsEnabled,
       notificationsHost,
@@ -74,6 +82,8 @@ object Configuration extends Logging {
       crossAccountDynamoRole,
       contentDynamoTableName,
       contentLiveBlogDynamoTableName,
+      crossAccountSqsRole,
+      crossAccountSqs,
       stage)
   }
 

--- a/src/main/scala/com/gu/mobile/content/notifications/ContentLambda.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/ContentLambda.scala
@@ -7,11 +7,12 @@ object ContentLambda extends Lambda {
 
   def processContent(content: Content): Boolean = {
     logger.info(s"Processing ContendId: ${content.id} Published at: ${content.getLoggablePublicationDate}")
+
+    // Temporary: this is to support the mobile text-to-speech experiment
+    sqs.sendMessage(content.id)
+
     if (content.isRecent && content.followableTags.nonEmpty) {
       val haveSeen = dynamo.haveSeenContentItem(content.id)
-
-      // Temporary: this is to support the mobile text-to-speech experiment
-      sqs.sendMessage(content.id)
 
       if (haveSeen) {
         logger.info(s"Ignoring duplicate content ${content.id}")

--- a/src/main/scala/com/gu/mobile/content/notifications/ContentLambda.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/ContentLambda.scala
@@ -9,6 +9,10 @@ object ContentLambda extends Lambda {
     logger.info(s"Processing ContendId: ${content.id} Published at: ${content.getLoggablePublicationDate}")
     if (content.isRecent && content.followableTags.nonEmpty) {
       val haveSeen = dynamo.haveSeenContentItem(content.id)
+
+      // Temporary: this is to support the mobile text-to-speech experiment
+      sqs.sendMessage(content.id)
+
       if (haveSeen) {
         logger.info(s"Ignoring duplicate content ${content.id}")
       } else {

--- a/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
@@ -50,8 +50,10 @@ trait Lambda extends Logging {
       .withRegion(Regions.EU_WEST_1)
       .withCredentials(credentialsProvider)
       .build()
-    val queueUrl = sqs.getQueueUrl(configuration.sqsQueue).getQueueUrl
-    logger.info(s"Retrieved queue url $queueUrl")
+    logger.info(s"created sqs client")
+
+    val queueUrl = configuration.sqsQueue
+    logger.info(s"Retrieved queue url")
     val msg = new SendMessageRequest()
       .withQueueUrl(queueUrl)
       .withMessageBody("test")

--- a/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
@@ -45,7 +45,7 @@ trait Lambda extends Logging {
 
     val credentialsProvider = new AWSCredentialsProviderChain(
       new ProfileCredentialsProvider(),
-      new STSAssumeRoleSessionCredentialsProvider.Builder("arn:aws:iam::201359054765:role/mobile-content-notifications-lambda-cross-account-sqs-CODE", "mobile-sqs").build())
+      new STSAssumeRoleSessionCredentialsProvider.Builder("arn:aws:iam::201359054765:role/mobile-content-notifications-lambda-cross-account2-sqs-CODE", "mobile-sqs").build())
     val sqs = AmazonSQSClientBuilder.standard()
       .withRegion(Regions.EU_WEST_1)
       .withCredentials(credentialsProvider)

--- a/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
@@ -46,11 +46,12 @@ trait Lambda extends Logging {
     val credentialsProvider = new AWSCredentialsProviderChain(
       new ProfileCredentialsProvider(),
       new STSAssumeRoleSessionCredentialsProvider.Builder(configuration.crossAccountSqsRole, "mobile-sqs").build())
+    logger.info(s"credentials provider ${credentialsProvider.toString}")
     val sqs = AmazonSQSClientBuilder.standard()
       .withRegion(Regions.EU_WEST_1)
       .withCredentials(credentialsProvider)
       .build()
-    logger.info(s"created sqs client")
+    logger.info(s"created sqs client ${sqs.toString}")
 
     val queueUrl = configuration.sqsQueue
     logger.info(s"Retrieved queue url")

--- a/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
@@ -45,17 +45,17 @@ trait Lambda extends Logging {
 
     val credentialsProvider = new AWSCredentialsProviderChain(
       new ProfileCredentialsProvider(),
-      new STSAssumeRoleSessionCredentialsProvider.Builder("arn:aws:iam::201359054765:role/mobile-content-notifications-lambda-cross-account2-sqs-CODE", "mobile-sqs").build())
+      new STSAssumeRoleSessionCredentialsProvider.Builder(configuration.crossAccountSqsRole, "mobile-sqs").build())
     val sqs = AmazonSQSClientBuilder.standard()
       .withRegion(Regions.EU_WEST_1)
       .withCredentials(credentialsProvider)
       .build()
-    val queueUrl = sqs.getQueueUrl("mobile-CODE-mobile-audio-generator-capiFirehoseEvents89AEA846-qnv7gNSYqGby").getQueueUrl
-    logger.debug(s"Retrieved queue url $queueUrl")
+    val queueUrl = sqs.getQueueUrl(configuration.sqsQueue).getQueueUrl
+    logger.info(s"Retrieved queue url $queueUrl")
     val msg = new SendMessageRequest()
       .withQueueUrl(queueUrl)
       .withMessageBody("test")
-    logger.debug(s"About to send message ${msg.toString}")
+    logger.info(s"About to send message ${msg.toString}")
     sqs.sendMessage(msg)
 
     CapiEventProcessor.process(userRecords) { event =>

--- a/src/main/scala/com/gu/mobile/content/notifications/lib/MobileSqs.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/lib/MobileSqs.scala
@@ -1,0 +1,37 @@
+package com.gu.mobile.content.notifications.lib
+
+import com.amazonaws.auth.{AWSCredentialsProviderChain, STSAssumeRoleSessionCredentialsProvider}
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.sqs.{AmazonSQS, AmazonSQSClientBuilder, model}
+import com.amazonaws.services.sqs.model.SendMessageRequest
+import com.gu.mobile.content.notifications.{Configuration, Logging}
+
+class MobileSqs(client: AmazonSQS, config: Configuration) extends Logging {
+  def sendMessage(contentId: String): Unit = {
+    val msg = new SendMessageRequest()
+      .withQueueUrl(config.sqsQueue)
+      .withMessageBody(contentId)
+
+    logger.info(s"About to send message to mobile SQS: ${msg.toString}")
+
+    client.sendMessage(msg)
+  }
+}
+
+object MobileSqs extends Logging {
+    def apply(config: Configuration): MobileSqs = {
+      logger.info(s"Configuring sqs permissions with cross account role: ${config.crossAccountSqsRole}")
+
+      val credentialsProvider = new AWSCredentialsProviderChain(
+        new ProfileCredentialsProvider(),
+        new STSAssumeRoleSessionCredentialsProvider.Builder(config.crossAccountSqsRole, "mobile-sqs").build())
+
+      val client = AmazonSQSClientBuilder.standard()
+        .withRegion(Regions.EU_WEST_1)
+        .withCredentials(credentialsProvider)
+        .build()
+
+      new MobileSqs(client, config)
+    }
+}

--- a/src/test/scala/com/gu/mobile/content/notifications/lib/MessageSenderSpec.scala
+++ b/src/test/scala/com/gu/mobile/content/notifications/lib/MessageSenderSpec.scala
@@ -21,7 +21,7 @@ import scala.concurrent.Future
 
 class MessageSenderSpec extends MockitoSugar with WordSpecLike with MustMatchers with OneInstancePerTest with BeforeAndAfterEach with ScalaFutures {
 
-  val config = new Configuration(true, "", "", "", "", "", "", "")
+  val config = new Configuration(true, "", "", "", "", "", "", "", "", "")
   val apiClient = mock[NotificationsApiClient]
   val content = mock[Content]
   val mockPayload = mock[ContentAlertPayload]


### PR DESCRIPTION
This is in draft at the moment, I don't think we need to deploy this to PROD right now. At the moment MAPI only creates the required resources for CODE (see here for ref: https://github.com/guardian/mobile-apps-api/pull/2703)

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
