### PR TITLE
Fix netty snyk vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,9 +25,13 @@ assembly / assemblyMergeStrategy := {
 }
 
 val awsSdkVersion = "1.11.772"
+val awsSdk2Version = "2.21.21"
 
 libraryDependencies ++= Seq(
-  "software.amazon.awssdk" % "sts" % "2.20.162",
+  "software.amazon.awssdk" % "sts" % awsSdk2Version,
+  "software.amazon.awssdk" % "autoscaling" % awsSdk2Version,
+  "software.amazon.awssdk" % "ec2" % awsSdk2Version,
+  "software.amazon.awssdk" % "ssm" % awsSdk2Version,
   "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
   "com.amazonaws" % "amazon-kinesis-client" % "1.14.8",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Snyk scanning detected high vulnerability in netty-https library v4.1.94, which was introduced as a transitive dependency via AWS SDK v2.

In order to fix this vulnerability, this PR bumps the AWS SDK v2 to v2.21.21 so that the fixed version of netty (v4.1.100) will be used.  It also specifies the version of "software.amazon.awssdk:autoscaling", "software.amazon.awssdk:ec2", "software.amazon.awssdk:ssm" to v2.21.21 so that we use the same minor/bugfix version across all AWS SDK v2 modules.

All unit tests passed.
