### PR TITLE
Add method to change lamdba event to KCL record

### DIFF
--- a/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
@@ -34,9 +34,29 @@ trait Lambda extends Logging {
 
   implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
+  /***
+    As of version 3.0.0 of aws-lambda-java-events: https://github.com/aws/aws-lambda-java-libs/blob/main/aws-lambda-java-events/RELEASE.CHANGELOG.md#may-18-2020
+    reading records from the lambda event returns a different model to the one that the kinesis client library deaggregation
+    method is expecting.
+
+    According to the amazon docs: https://docs.aws.amazon.com/streams/latest/dev/lambda-consumer.html we should be
+    importing a custom deaggregation library for running in a lambda. However, the library is not officially
+    supported by AWS and the version we require is not available on maven. See https://github.com/awslabs/kinesis-aggregation/issues/120
+
+    So, manually creating an object of the type that the KCL library is expecting feels like the least worst option
+   ***/
+  def kinesisEventRecordToRecord(eventRecord: KinesisEvent.Record): Record = {
+    new Record()
+      .withSequenceNumber(eventRecord.getSequenceNumber)
+      .withApproximateArrivalTimestamp(eventRecord.getApproximateArrivalTimestamp)
+      .withData(eventRecord.getData)
+      .withPartitionKey(eventRecord.getPartitionKey)
+      .withEncryptionType(eventRecord.getEncryptionType)
+  }
   def handler(event: KinesisEvent): Unit = {
-    val rawRecord: List[Record] = event.getRecords.asScala.map(_.getKinesis).toList
-    val userRecords: List[UserRecord] = UserRecord.deaggregate(rawRecord.asJava).asScala.toList
+    val eventRecords: List[KinesisEvent.Record] = event.getRecords.asScala.toList.map(_.getKinesis)
+    val records = eventRecords.map(kinesisEventRecordToRecord)
+    val userRecords: List[UserRecord] = UserRecord.deaggregate(records.asJava).asScala.toList
 
     CapiEventProcessor.process(userRecords) { event =>
       event.eventType match {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This adds a method to translate the type returned from the lambda event record to the object type that the kinesis client library is expecting. 

 As of version 3.0.0 of [aws-lambda-java-events](https://github.com/aws/aws-lambda-java-libs/blob/main/aws-lambda-java-events/RELEASE.CHANGELOG.md#may-18-2020) reading records from the lambda event returns a different model to the one that the kinesis client library deaggregation method is expecting.

According to the [amazon docs](https://docs.aws.amazon.com/streams/latest/dev/lambda-consumer.html) we should be importing a custom deaggregation library for running in a lambda. However, the library is not officially supported by AWS and the version we require is not available on maven. See [this issue](https://github.com/awslabs/kinesis-aggregation/issues/120) for more information. 

I think this approach is our best option to enable us to be able to upgrade aws libraries 
 

## How to test
Tested on CODE that publishing an article in CAPI results in log statement produced in the`notification` app which says: `ContentNotification`

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
