### PR TITLE
Remove lambda code deployment in riffraff step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,5 @@ jobs:
         projectName: Mobile::mobile-notifications-content
         buildNumberOffset: 466
         contentDirectories: |
-          mobile-notifications-content:
-          - mobile-notifications-content.jar
           mobile-notifications-content-cfn:
           - cfn.yaml

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -2,14 +2,6 @@ stacks: [content-api-mobile-notifications]
 regions: [eu-west-1]
 
 deployments:
-  mobile-notifications-content:
-    type: aws-lambda
-    parameters:
-      bucket: content-api-dist
-      functionNames: [mobile-notifications-content-liveblogs-, mobile-notifications-content-]
-      fileName: mobile-notifications-content.jar
-      prefixStack: false
-    dependencies: [mobile-notifications-content-cfn]
   mobile-notifications-content-cfn:
     type: cloud-formation
     app: mobile-notifications-content


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This takes out the C.I step to generate a jar of the code, and removes the lambda deployment step. This is because since we moved to use a [containerised lambda](https://github.com/guardian/mobile-notifications-content/pull/62) generating the image is now handled in CI, and bumping the code version number is handled in the cloudformation script. So we no longer need to generate the artifact

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
