### PR TITLE
Non AWS dependency upgrade + logging fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,6 @@ libraryDependencies ++= Seq(
   "org.joda" % "joda-convert" % "1.8.3",
   "org.jsoup" % "jsoup" % "1.15.4",
   "com.typesafe.play" %% "play-json" % "2.8.2",
-  //https://www.slf4j.org/faq.html#changesInVersion200
   "org.slf4j" % "slf4j-simple" % "2.0.13",
   "org.slf4j" % "slf4j-api" % "2.0.13",
   "com.typesafe.akka" %% "akka-actor" % "2.5.24",

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ description:= "lambda to replace the content-notifications-service"
 
 version := "1.0"
 
-scalaVersion := "2.13.5"
+scalaVersion := "2.13.12"
 
 scalacOptions ++= Seq(
   "-deprecation",
@@ -38,24 +38,24 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.4",
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
-  "com.gu" %% "content-api-client-default" % "19.0.4",
-  "com.gu" %% "mobile-notifications-api-models" % "1.0.15",
-  "com.gu" %% "thrift-serializer" % "4.0.3",
-  "org.joda" % "joda-convert" % "1.8.1",
-  "org.jsoup" % "jsoup" % "1.15.3",
-  "com.typesafe.play" %% "play-json" % "2.8.1",
-  "org.slf4j" % "slf4j-simple" % "1.7.25",
+  "com.gu" %% "content-api-client-default" % "19.0.5",
+  "com.gu" %% "mobile-notifications-api-models" % "1.0.16",
+  "com.gu" %% "thrift-serializer" % "5.0.2",
+  "org.joda" % "joda-convert" % "1.8.3",
+  "org.jsoup" % "jsoup" % "1.15.4",
+  "com.typesafe.play" %% "play-json" % "2.8.2",
+  "org.slf4j" % "slf4j-simple" % "1.7.36",
   "com.typesafe.akka" %% "akka-actor" % "2.5.24",
-  "com.squareup.okhttp3" % "okhttp" % "3.14.8",
-  "com.gu" %% "simple-configuration-ssm" % "1.5.6",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.4",
-  "com.squareup.okhttp3" % "okhttp" % "4.10.0",
-  "com.google.protobuf" % "protobuf-java" % "3.19.6",
-  "org.scalatest" %% "scalatest" % "3.0.8" % Test,
-  "org.mockito" % "mockito-all" % "1.9.0" % Test,
+  "com.squareup.okhttp3" % "okhttp" % "3.14.9",
+  "com.gu" %% "simple-configuration-ssm" % "1.5.8",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.5",
+  "com.squareup.okhttp3" % "okhttp" % "4.12.0",
+  "com.google.protobuf" % "protobuf-java" % "3.25.2",
+  "org.scalatest" %% "scalatest" % "3.0.9" % Test,
+  "org.mockito" % "mockito-all" % "1.9.5" % Test,
   "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % Test,
-  "org.specs2" %% "specs2-core" % "4.5.1" % Test,
-  "org.specs2" %% "specs2-matcher-extra" % "4.5.1" % Test
+  "org.specs2" %% "specs2-core" % "4.20.4" % Test,
+  "org.specs2" %% "specs2-matcher-extra" % "4.20.4" % Test
 )
 libraryDependencies += "com.github.luben" % "zstd-jni" % "1.5.5-3"
 

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
   "org.joda" % "joda-convert" % "1.8.3",
   "org.jsoup" % "jsoup" % "1.15.4",
   "com.typesafe.play" %% "play-json" % "2.8.2",
-  "org.slf4j" % "slf4j-simple" % "1.7.36",
+  "org.slf4j" % "slf4j-simple" % "1.7.25",
   "com.typesafe.akka" %% "akka-actor" % "2.5.24",
   "com.squareup.okhttp3" % "okhttp" % "3.14.9",
   "com.gu" %% "simple-configuration-ssm" % "1.5.8",

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,9 @@ libraryDependencies ++= Seq(
   "org.joda" % "joda-convert" % "1.8.3",
   "org.jsoup" % "jsoup" % "1.15.4",
   "com.typesafe.play" %% "play-json" % "2.8.2",
-  "org.slf4j" % "slf4j-simple" % "1.7.25",
+  //https://www.slf4j.org/faq.html#changesInVersion200
+  "org.slf4j" % "slf4j-simple" % "2.0.13",
+  "org.slf4j" % "slf4j-api" % "2.0.13",
   "com.typesafe.akka" %% "akka-actor" % "2.5.24",
   "com.squareup.okhttp3" % "okhttp" % "3.14.9",
   "com.gu" %% "simple-configuration-ssm" % "1.5.8",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.7.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 

--- a/src/main/scala/com/gu/mobile/content/notifications/Configuration.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/Configuration.scala
@@ -1,11 +1,15 @@
 package com.gu.mobile.content.notifications
 
+import com.amazonaws.regions.Regions
 import com.gu.conf.{ ConfigurationLoader, SSMConfigurationLocation }
+import com.typesafe.config.Config
 import com.gu.{ AppIdentity, AwsIdentity }
 import software.amazon.awssdk.auth.credentials.{ AwsCredentialsProvider, AwsCredentialsProviderChain => AwsCredentialsProviderChainV2, ProfileCredentialsProvider => ProfileCredentialsProviderV2 }
 import software.amazon.awssdk.services.sts.StsClient
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest
+
+import scala.util.{ Failure, Success }
 
 case class Configuration(
   guardianNotificationsEnabled: Boolean,
@@ -38,10 +42,14 @@ object Configuration extends Logging {
       .build())
 
   val conf = {
-    val identity = AppIdentity.whoAmI(defaultAppName = appName)
-    ConfigurationLoader.load(identity = identity, credentials = credentialsProvider) {
+    (for {
+      identity <- AppIdentity.whoAmI(defaultAppName = appName, credentials = credentialsProvider)
+    } yield ConfigurationLoader.load(identity = identity, credentials = credentialsProvider) {
       case AwsIdentity(app, stack, stage, _) =>
-        SSMConfigurationLocation(path = s"/$app/$stage/$stack")
+        SSMConfigurationLocation(path = s"/$app/$stage/$stack", Regions.EU_WEST_1.getName)
+    }) match {
+      case Success(c) => c
+      case Failure(exception) => sys.error(s"Could not load config ${exception.getMessage}")
     }
   }
 

--- a/src/test/scala/com/gu/mobile/content/notifications/lib/MessageSenderSpec.scala
+++ b/src/test/scala/com/gu/mobile/content/notifications/lib/MessageSenderSpec.scala
@@ -69,13 +69,13 @@ class MessageSenderSpec extends MockitoSugar with WordSpecLike with MustMatchers
 
     "properly deserialize a compressed event" in {
       val bytes = ThriftSerializer.serializeToBytes(event, Some(ZstdType), None)
-      val record = new Record().withData(ByteBuffer.wrap(bytes))
+      val record = new Record().withData(bytes)
       CapiEventProcessor.process(List(record))(event => Future.successful(true)).futureValue mustEqual 1
     }
 
     "properly deserialize a non-compressed event" in {
       val bytes = ThriftSerializer.serializeToBytes(event, None, None)
-      val record = new Record().withData(ByteBuffer.wrap(bytes))
+      val record = new Record().withData(bytes)
       CapiEventProcessor.process(List(record))(event => Future.successful(true)).futureValue mustEqual 1
     }
   }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This includes the library updates from the non aws dependency updates that we needed to [revert](https://github.com/guardian/mobile-notifications-content/pull/59) because the logging configuration broke. 

Having looked at the error message output in the logs and read the documentation: https://www.slf4j.org/codes.html#ignoredBindings 

We need to include a provider, so I've added `slf4j-api` to the classpath

## How to test

Tested in CODE that our log statements are coming through ok

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
