### PR TITLE
Explicitly match on atoms to reduce logging

### DIFF
--- a/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
@@ -69,6 +69,9 @@ trait Lambda extends Logging {
             case EventPayload.RetrievableContent(content) =>
               logger.debug(s"Handle retrievable content or not: ${content.id}")
               handleRetrievableContent(content)
+            case EventPayload.Atom(atomAlias) =>
+              logger.debug(s"Unsupported content type: Atom, with id ${atomAlias.id}")
+              Future.successful(false)
             case UnknownUnionField(e) =>
               logger.error(s"Unknown event payload $e. Consider updating capi models")
               Future.successful(false)

--- a/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
@@ -70,7 +70,7 @@ trait Lambda extends Logging {
               logger.debug(s"Handle retrievable content or not: ${content.id}")
               handleRetrievableContent(content)
             case EventPayload.Atom(atomAlias) =>
-              logger.debug(s"Unsupported content type: Atom, with id ${atomAlias.id}")
+              logger.info(s"Unsupported content type: Atom, with id ${atomAlias.id}")
               Future.successful(false)
             case UnknownUnionField(e) =>
               logger.error(s"Unknown event payload $e. Consider updating capi models")


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR includes `Atom` into the match from content returned from Capi so that we can log this separately and reduce the noise in the logs incurred by lots of modifications to the football euros 

## How to test
I've tested on CODE the lambda still runs ok. 

I haven't been able to fully reproduce the issue on CODE, but I think we will be able to observe whether this fixes the issues ok in PROD easily enough

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
