### PR TITLE
Delete the deprecated lambdas

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -113,27 +113,6 @@ Resources:
                   - cloudwatch:PutMetricData
                Resource: "*"
 
-  ContentLambda:
-    Type: AWS::Lambda::Function
-    Properties:
-      FunctionName: !Sub ${App}-${Stage}
-      Code:
-        S3Bucket:
-          Ref: DeployBucket
-        S3Key: !Sub ${Stack}/${Stage}/${App}/${App}.jar
-      Environment:
-        Variables:
-          CrossAccountSsmReadingRole: !Sub arn:aws:iam::${MobileAccountId}:role/${CrossAccountBaseRoleName}-ssm-${Stage}
-          App: !Sub ${App}
-          Stack: !Sub ${Stack}
-          Stage: !Sub ${Stage}
-      Description: Lambda to send notification when new content is published
-      Handler: com.gu.mobile.content.notifications.ContentLambda::handler
-      MemorySize: 4096
-      Role: !GetAtt ExecutionRole.Arn
-      Runtime: java11
-      Timeout: 60
-
   ContentLambdaV2:
     Type: AWS::Lambda::Function
     Properties:
@@ -156,14 +135,6 @@ Resources:
       Role: !GetAtt ExecutionRole.Arn
       Timeout: 60
 
-  ContentEventSource:
-    Type: AWS::Lambda::EventSourceMapping
-    Properties:
-      FunctionName: !Ref ContentLambda
-      Enabled: false
-      EventSourceArn: !Sub arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${KinesisStreamName}-${Stage}
-      StartingPosition: LATEST
-      BisectBatchOnFunctionError: true
 
   ContentEventV2Source:
     Type: AWS::Lambda::EventSourceMapping
@@ -173,27 +144,6 @@ Resources:
       EventSourceArn: !Sub arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${KinesisStreamName}-${Stage}
       StartingPosition: LATEST
       BisectBatchOnFunctionError: true
-
-  LiveBlogLambda:
-    Type: AWS::Lambda::Function
-    Properties:
-      FunctionName: !Sub ${App}-liveblogs-${Stage}
-      Code:
-        S3Bucket:
-          Ref: DeployBucket
-        S3Key: !Sub ${Stack}/${Stage}/${App}/${App}.jar
-      Environment:
-        Variables:
-          CrossAccountSsmReadingRole: !Sub arn:aws:iam::${MobileAccountId}:role/${CrossAccountBaseRoleName}-ssm-${Stage}
-          App: !Sub ${App}
-          Stack: !Sub ${Stack}
-          Stage: !Sub ${Stage}
-      Description: Lambda that sends push notifications when new key events are published on a liveblog
-      Handler: com.gu.mobile.content.notifications.LiveBlogLambda::handler
-      MemorySize: 4096
-      Role: !GetAtt ExecutionRole.Arn
-      Runtime: java11
-      Timeout: 60
 
   LiveBlogLambdaV2:
     Type: AWS::Lambda::Function
@@ -216,15 +166,6 @@ Resources:
       MemorySize: 4096
       Role: !GetAtt ExecutionRole.Arn
       Timeout: 60
-
-  LiveBlogEventSource:
-    Type: AWS::Lambda::EventSourceMapping
-    Properties:
-      FunctionName: !Ref LiveBlogLambda
-      Enabled: false
-      EventSourceArn: !Sub arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${KinesisStreamName}-${Stage}
-      StartingPosition: LATEST
-      BisectBatchOnFunctionError: true
 
   LiveBlogEventSourceV2:
     Type: AWS::Lambda::EventSourceMapping


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This deletes the lambdas that were previously used to run the service, but have now been replaced in favour of [lambdas running a docker image](https://github.com/guardian/mobile-notifications-content/pull/62)

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
