### PR TITLE
Remove play-json from dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,6 @@ libraryDependencies ++= Seq(
   "com.gu" %% "thrift-serializer" % "5.0.2",
   "org.joda" % "joda-convert" % "1.8.3",
   "org.jsoup" % "jsoup" % "1.15.4",
-  "com.typesafe.play" %% "play-json" % "2.8.2",
   "org.slf4j" % "slf4j-simple" % "2.0.13",
   "org.slf4j" % "slf4j-api" % "2.0.13",
   "com.typesafe.akka" %% "akka-actor" % "2.5.24",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
_Co-authored-by: @alinaboghiu @rtyley_
## What does this change?
In the past week, we experienced issues with mobile notifications not being sent out. Logs were indicating `void play.api.libs.json.Format.$init$(play.api.libs.json.Format)` errors since upgrading the `mobile-notifications-api-models` library from `1.0.16` to `1.0.18`. 

@rtyley helpfully pointed out this was due to a conflict in the version of the `play-json` library that this project is using vs. the [version](https://github.com/guardian/mobile-n10n/blob/main/build.sbt#L37) `mobile-notifications-api-models` library is using. Normally scala would default to using the latest version of the library in case of such conflict but the because the [author of this library has changed](https://mvnrepository.com/artifact/com.typesafe.play/play-json) (`com.typesafe.play` → `org.playframework`), it resulted in the conflict.

This PR therefore removes the play-json from the project dependencies as we can import the correct version via the  `mobile-notifications-api-models` library.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
I tested this on CODE by creating a test article on composer CODE. The logs look healthy

[Lambda logs](https://logs.gutools.co.uk/s/content-platforms/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(columns:!(),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:b0be43a0-59d7-11e8-a75a-b7af20e8f748,key:stage,negate:!f,params:(query:CODE),type:phrase),query:(match_phrase:(stage:CODE))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:b0be43a0-59d7-11e8-a75a-b7af20e8f748,key:app,negate:!f,params:(query:mobile-notifications-content),type:phrase),query:(match_phrase:(app:mobile-notifications-content)))),index:b0be43a0-59d7-11e8-a75a-b7af20e8f748,interval:auto,query:(language:kuery,query:''),sort:!(!('@timestamp',desc))))
![image](https://github.com/user-attachments/assets/0aa63867-56c0-44f4-aebd-9d1f5a06b7bd)

[Notification api logs](https://logs.gutools.co.uk/s/mobile/app/discover#/view/8cc67480-07a1-11ef-a06c-911a16951718?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-2h,to:now))&_a=(columns:!(message),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'26bd67e0-d55e-11e9-923e-49c5b785a0b2',key:app,negate:!f,params:(query:notification),type:phrase),query:(match_phrase:(app:notification))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'26bd67e0-d55e-11e9-923e-49c5b785a0b2',key:stage,negate:!f,params:(query:CODE),type:phrase),query:(match_phrase:(stage:CODE)))),grid:(),hideChart:!f,index:'26bd67e0-d55e-11e9-923e-49c5b785a0b2',interval:auto,query:(language:kuery,query:'%22Notification%20was%20sent%22'),sort:!(!('@timestamp',desc))))
![image](https://github.com/user-attachments/assets/a106c0e3-e102-4a00-8e98-5d16aa5441f0)

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

