### PR TITLE
Pin com.github.luben zstd-jni 1.5.5-3

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,4 @@
+updates.pin  = [
+    # the latest version 1.5.5-11 produces a binary conflict with com.gu:thrift-serializer_2.13:5.0.7
+    { groupId = "com.github.luben", artifactId="zstd-jni ", version = "1.5.5-3" }
+ ]

--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ libraryDependencies ++= Seq(
   "org.mockito" % "mockito-all" % "1.10.19" % Test,
   "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % Test,
   "org.specs2" %% "specs2-core" % "4.20.8" % Test,
-  "org.specs2" %% "specs2-matcher-extra" % "4.20.4" % Test
+  "org.specs2" %% "specs2-matcher-extra" % "4.20.8" % Test
 )
 libraryDependencies += "com.github.luben" % "zstd-jni" % "1.5.5-3"
 

--- a/build.sbt
+++ b/build.sbt
@@ -59,6 +59,6 @@ libraryDependencies ++= Seq(
   "org.specs2" %% "specs2-core" % "4.20.8" % Test,
   "org.specs2" %% "specs2-matcher-extra" % "4.20.4" % Test
 )
-libraryDependencies += "com.github.luben" % "zstd-jni" % "1.5.5-11"
+libraryDependencies += "com.github.luben" % "zstd-jni" % "1.5.5-3"
 
 assemblyJarName := s"${name.value}.jar"

--- a/src/test/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilderSpec.scala
+++ b/src/test/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilderSpec.scala
@@ -8,9 +8,9 @@ import com.gu.mobile.notifications.client.models.TopicTypes.{ TagBlog, TagContri
 import com.gu.mobile.notifications.client.models._
 import org.joda.time.{ DateTime, LocalDate }
 import org.scalatestplus.mockito.MockitoSugar
-import org.specs2.matcher.MustMatchers
-
-class ContentAlertPayloadBuilderSpec extends MockitoSugar with MustMatchers {
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+class ContentAlertPayloadBuilderSpec extends MockitoSugar with AnyWordSpecLike with Matchers {
 
   val conf = mock[Configuration]
   val builder = new ContentAlertPayloadBuilder {

--- a/src/test/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilderSpec.scala
+++ b/src/test/scala/com/gu/mobile/content/notifications/lib/ContentAlertPayloadBuilderSpec.scala
@@ -7,10 +7,10 @@ import com.gu.mobile.content.notifications.model.KeyEvent
 import com.gu.mobile.notifications.client.models.TopicTypes.{ TagBlog, TagContributor, TagKeyword, TagSeries }
 import com.gu.mobile.notifications.client.models._
 import org.joda.time.{ DateTime, LocalDate }
-import org.scalatest.{ MustMatchers, WordSpecLike }
 import org.scalatestplus.mockito.MockitoSugar
+import org.specs2.matcher.MustMatchers
 
-class ContentAlertPayloadBuilderSpec extends MockitoSugar with WordSpecLike with MustMatchers {
+class ContentAlertPayloadBuilderSpec extends MockitoSugar with MustMatchers {
 
   val conf = mock[Configuration]
   val builder = new ContentAlertPayloadBuilder {

--- a/src/test/scala/com/gu/mobile/content/notifications/lib/MessageSenderSpec.scala
+++ b/src/test/scala/com/gu/mobile/content/notifications/lib/MessageSenderSpec.scala
@@ -10,7 +10,9 @@ import org.mockito.ArgumentCaptor
 import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{ BeforeAndAfterEach, MustMatchers, OneInstancePerTest, WordSpecLike, Matchers => ShouldMatchers }
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.{ BeforeAndAfterEach, OneInstancePerTest }
+import org.scalatest.matchers.must.{ Matchers => ShouldMatchers }
 import org.scalatestplus.mockito.MockitoSugar
 import software.amazon.kinesis.retrieval.KinesisClientRecord
 
@@ -19,7 +21,7 @@ import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class MessageSenderSpec extends MockitoSugar with WordSpecLike with MustMatchers with OneInstancePerTest with BeforeAndAfterEach with ScalaFutures {
+class MessageSenderSpec extends MockitoSugar with AnyWordSpecLike with ShouldMatchers with OneInstancePerTest with BeforeAndAfterEach with ScalaFutures {
 
   val config = new Configuration(true, "", "", "", "", "", "", "")
   val apiClient = mock[NotificationsApiClient]

--- a/src/test/scala/com/gu/mobile/content/notifications/metrics/MetricsActorSpec.scala
+++ b/src/test/scala/com/gu/mobile/content/notifications/metrics/MetricsActorSpec.scala
@@ -4,11 +4,12 @@ import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest
 import org.mockito.Mockito._
 import org.mockito.{ ArgumentCaptor, Matchers }
-import org.scalatest.{ MustMatchers, WordSpecLike }
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.matchers.must.{ Matchers => ShouldMatchers }
 import org.scalatestplus.mockito.MockitoSugar
 import org.specs2.specification.Scope
 
-class MetricsActorSpec extends WordSpecLike with MockitoSugar with MustMatchers {
+class MetricsActorSpec extends AnyWordSpecLike with MockitoSugar with ShouldMatchers {
 
   "The Metric Actor Logic" should {
     "not call cloudwatch if there is not data" in new MetricActorScope {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This pins com.github.luben zstd-jni 1.5.5-3 because the later version produces a binary incompatibility

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
