### PR TITLE
Upgrade to java 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@v4
       with:
         distribution: 'corretto'
-        java-version: '11'
+        java-version: '21'
         cache: 'sbt'
 
     - name: Build and Test project, Assemble jar, copy to root dir

--- a/build.sbt
+++ b/build.sbt
@@ -55,8 +55,8 @@ libraryDependencies ++= Seq(
   "org.json" % "json" % "20240303",
   "org.apache.commons" % "commons-compress" % "1.26.0",
   "org.scalatest" %% "scalatest" % "3.0.9" % Test,
-  "org.mockito" % "mockito-all" % "1.9.5" % Test,
-  "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % Test,
+  "org.mockito" % "mockito-core" % "5.13.0" % Test,
+  "org.scalatestplus" %% "mockito-5-12" % "3.2.19.0" % Test,
   "org.specs2" %% "specs2-core" % "4.20.4" % Test,
   "org.specs2" %% "specs2-matcher-extra" % "4.20.4" % Test
 )

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,8 @@ scalaVersion := "2.13.13"
 scalacOptions ++= Seq(
   "-deprecation",
   "-encoding", "UTF-8",
-  "-Ywarn-dead-code"
+  "-Ywarn-dead-code",
+  "-release:21"
 )
 
 resolvers ++= Seq(

--- a/mobile-notifications-content.Dockerfile
+++ b/mobile-notifications-content.Dockerfile
@@ -1,4 +1,4 @@
 
-FROM public.ecr.aws/lambda/java:11
+FROM public.ecr.aws/lambda/java:21
 COPY mobile-notifications-content.jar ${LAMBDA_TASK_ROOT}/lib/
 CMD ["com.gu.mobile.content.notifications.ContentLambda::handler"]

--- a/mobile-notifications-liveblogs.Dockerfile
+++ b/mobile-notifications-liveblogs.Dockerfile
@@ -1,4 +1,4 @@
 
-FROM public.ecr.aws/lambda/java:11
+FROM public.ecr.aws/lambda/java:21
 COPY mobile-notifications-content.jar ${LAMBDA_TASK_ROOT}/lib/
 CMD ["com.gu.mobile.content.notifications.LiveBlogLambda::handler"]

--- a/src/test/scala/com/gu/mobile/content/notifications/metrics/MetricsActorSpec.scala
+++ b/src/test/scala/com/gu/mobile/content/notifications/metrics/MetricsActorSpec.scala
@@ -3,7 +3,8 @@ package com.gu.mobile.content.notifications.metrics
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest
 import org.mockito.Mockito._
-import org.mockito.{ ArgumentCaptor, Matchers }
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
 import org.scalatest.{ MustMatchers, WordSpecLike }
 import org.scalatestplus.mockito.MockitoSugar
 import org.specs2.specification.Scope
@@ -13,7 +14,7 @@ class MetricsActorSpec extends WordSpecLike with MockitoSugar with MustMatchers 
   "The Metric Actor Logic" should {
     "not call cloudwatch if there is not data" in new MetricActorScope {
       actorLogic.aggregatePoint(Nil)
-      verify(mockCloudWatch, times(0)).putMetricData(Matchers.any[PutMetricDataRequest])
+      verify(mockCloudWatch, times(0)).putMetricData(any[PutMetricDataRequest])
     }
     "call cloudwatch once if there's one namespace with less than 20 points" in new MetricActorScope {
       val metrics = List(
@@ -54,7 +55,7 @@ class MetricsActorSpec extends WordSpecLike with MockitoSugar with MustMatchers 
         MetricDataPoint("test", "m2", 1d),
         MetricDataPoint("test", "m3", 2d))
       actorLogic.aggregatePoint(metrics)
-      verify(mockCloudWatch, times(1)).putMetricData(Matchers.any[PutMetricDataRequest])
+      verify(mockCloudWatch, times(1)).putMetricData(any[PutMetricDataRequest])
     }
     "call cloudwatch as many times as we have namespaces" in new MetricActorScope {
       val metrics = List(
@@ -62,7 +63,7 @@ class MetricsActorSpec extends WordSpecLike with MockitoSugar with MustMatchers 
         MetricDataPoint("namespace2", "m2", 1d),
         MetricDataPoint("namespace2", "m1", 2d))
       actorLogic.aggregatePoint(metrics)
-      verify(mockCloudWatch, times(2)).putMetricData(Matchers.any[PutMetricDataRequest])
+      verify(mockCloudWatch, times(2)).putMetricData(any[PutMetricDataRequest])
     }
     "aggregate points into a MetricDatum" in new MetricActorScope {
       val metrics = List(
@@ -91,7 +92,7 @@ class MetricsActorSpec extends WordSpecLike with MockitoSugar with MustMatchers 
       }
       actorLogic.aggregatePoint(metrics)
       val requestCaptor = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
-      verify(mockCloudWatch, times(2)).putMetricData(Matchers.any[PutMetricDataRequest])
+      verify(mockCloudWatch, times(2)).putMetricData(any[PutMetricDataRequest])
     }
 
     "not aggregate points into multiple batches if there are 20 metrics or less per namespace" in new MetricActorScope {
@@ -100,7 +101,7 @@ class MetricsActorSpec extends WordSpecLike with MockitoSugar with MustMatchers 
       }
       actorLogic.aggregatePoint(metrics)
       val requestCaptor = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
-      verify(mockCloudWatch, times(1)).putMetricData(Matchers.any[PutMetricDataRequest])
+      verify(mockCloudWatch, times(1)).putMetricData(any[PutMetricDataRequest])
     }
   }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This upgrades run time version of Java to Java 21. This also upgrades the mockito testing library, as there was a dependency on this update in order for the tests to run with the Java upgrade. 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
