### PR TITLE
Add alarm for the content lambda

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -226,3 +226,55 @@ Resources:
       EventSourceArn: !Sub arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${KinesisStreamName}-${Stage}
       StartingPosition: LATEST
       BisectBatchOnFunctionError: true
+
+  liveBlogLambdaErrorPercentageAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side-${Stage}
+      AlarmName:
+        Fn::Join:
+          - '-'
+          - - 'liveblogLambdaErrorPercentageAlarm'
+            - !Ref Stage
+      AlarmDescription: 'Impact - Users that are subscribed to liveblog notifications may not be getting the latest updates'
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      Metrics:
+        - Expression: 100*m1/m2
+          Id: expr_1
+          Label:
+            Fn::Join:
+              - ""
+              - - "Error % of "
+                - Ref: LiveBlogLambdaV2
+        - Id: m1
+          MetricStat:
+            Metric:
+              Dimensions:
+                - Name: FunctionName
+                  Value:
+                    Ref: LiveBlogLambdaV2
+              MetricName: Errors
+              Namespace: AWS/Lambda
+            Period: 60
+            Stat: Sum
+          ReturnData: false
+        - Id: m2
+          MetricStat:
+            Metric:
+              Dimensions:
+                - Name: FunctionName
+                  Value:
+                    Ref: LiveBlogLambdaV2
+              MetricName: Invocations
+              Namespace: AWS/Lambda
+            Period: 60
+            Stat: Sum
+          ReturnData: false
+      OKActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side-${Stage}
+      Threshold: 1
+      TreatMissingData: notBreaching
+    DependsOn: LiveBlogLambdaV2

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -119,7 +119,7 @@ Resources:
               Action:
                 - sns:Publish
               Resource:
-                - !Sub arn:aws:sns:${AWS::Region}:${AWS::MobileAccountId}:mobile-server-side-${Stage}
+                - !Sub arn:aws:sns:${AWS::Region}:${MobileAccountId}:mobile-server-side-${Stage}
 
   ContentLambdaV2:
     Type: AWS::Lambda::Function
@@ -157,7 +157,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::MobileAccountId}:mobile-server-side-${Stage}
+        - !Sub arn:aws:sns:${AWS::Region}:${MobileAccountId}:mobile-server-side-${Stage}
       AlarmName:
         Fn::Join:
           - '-'
@@ -199,7 +199,7 @@ Resources:
             Stat: Sum
           ReturnData: false
       OKActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::MobileAccountId}:mobile-server-side-${Stage}
+        - !Sub arn:aws:sns:${AWS::Region}:${MobileAccountId}:mobile-server-side-${Stage}
       Threshold: 1
       TreatMissingData: notBreaching
     DependsOn: ContentLambdaV2
@@ -240,7 +240,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::MobileAccountId}:mobile-server-side-${Stage}
+        - !Sub arn:aws:sns:${AWS::Region}:${MobileAccountId}:mobile-server-side-${Stage}
       AlarmName:
         Fn::Join:
           - '-'
@@ -282,7 +282,7 @@ Resources:
             Stat: Sum
           ReturnData: false
       OKActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::MobileAccountId}:mobile-server-side-${Stage}
+        - !Sub arn:aws:sns:${AWS::Region}:${MobileAccountId}:mobile-server-side-${Stage}
       Threshold: 1
       TreatMissingData: notBreaching
     DependsOn: LiveBlogLambdaV2

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -144,25 +144,55 @@ Resources:
       StartingPosition: LATEST
       BisectBatchOnFunctionError: true
 
-  ContentLambdaAlarm:
+  contentLambdaErrorPercentageAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      ActionsEnabled: true
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side-${Stage}
-      AlarmName: !Join
-        - ' '
-        - - 'ContentLambda'
-          - !Ref 'Stage'
-      AlarmDescription:  'Impact - Users that are subscribed to content notifications may not be getting the latest updates'
-      Namespace: AWS/Lambda
-      Dimensions:
-        - Name: FunctionName
-          Value: !Ref ContentLambdaV2
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      Threshold: 1
-      Period: 60
+      AlarmName:
+        Fn::Join:
+          - '-'
+          - - 'contentLambdaErrorPercentageAlarm'
+            - !Ref Stage
+      AlarmDescription:  'Impact - Users that are subscribed to content notifications may not be getting the latest updates'm
+      ComparisonOperator: GreaterThanThreshold
       EvaluationPeriods: 1
-      Statistic: Sum
+      Metrics:
+        - Expression: 100*m1/m2
+          Id: expr_1
+          Label:
+            Fn::Join:
+              - ""
+              - - "Error % of "
+                - Ref: ContentLambdaV2
+        - Id: m1
+          MetricStat:
+            Metric:
+              Dimensions:
+                - Name: FunctionName
+                  Value:
+                    Ref: ContentLambdaV2
+              MetricName: Errors
+              Namespace: AWS/Lambda
+            Period: 60
+            Stat: Sum
+          ReturnData: false
+        - Id: m2
+          MetricStat:
+            Metric:
+              Dimensions:
+                - Name: FunctionName
+                  Value:
+                    Ref: ContentLambdaV2
+              MetricName: Invocations
+              Namespace: AWS/Lambda
+            Period: 60
+            Stat: Sum
+          ReturnData: false
+      OKActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side-${Stage}
+      Threshold: 1
       TreatMissingData: notBreaching
     DependsOn: ContentLambdaV2
 

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -155,7 +155,7 @@ Resources:
           - '-'
           - - 'contentLambdaErrorPercentageAlarm'
             - !Ref Stage
-      AlarmDescription:  'Impact - Users that are subscribed to content notifications may not be getting the latest updates'
+      AlarmDescription:  'Triggers if mobile-notifications-content lambda does not execute successfully. Note: this lambda is hosted in the CAPI account. Impact - Users that are subscribed to tags or contributors on their mobile device may not be getting the latest updates'
       ComparisonOperator: GreaterThanThreshold
       EvaluationPeriods: 1
       Metrics:
@@ -238,7 +238,7 @@ Resources:
           - '-'
           - - 'liveblogLambdaErrorPercentageAlarm'
             - !Ref Stage
-      AlarmDescription: 'Impact - Users that are subscribed to liveblog notifications may not be getting the latest updates'
+      AlarmDescription: 'Triggers if mobile-notifications-content-liveblogs lambda does not execute successfully. Note: this lambda is hosted in the CAPI account. Impact - Users that are subscribed to liveblog notifications may not be getting the latest updates'
       ComparisonOperator: GreaterThanThreshold
       EvaluationPeriods: 1
       Metrics:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -135,7 +135,6 @@ Resources:
       Role: !GetAtt ExecutionRole.Arn
       Timeout: 60
 
-
   ContentEventV2Source:
     Type: AWS::Lambda::EventSourceMapping
     Properties:
@@ -144,6 +143,28 @@ Resources:
       EventSourceArn: !Sub arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${KinesisStreamName}-${Stage}
       StartingPosition: LATEST
       BisectBatchOnFunctionError: true
+
+  ContentLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side-${Stage}
+      AlarmName: !Join
+        - ' '
+        - - 'ContentLambda'
+          - !Ref 'Stage'
+      AlarmDescription:  'Impact - Users that are subscribed to content notifications may not be getting the latest updates'
+      Namespace: AWS/Lambda
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref ContentLambdaV2
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 1
+      Period: 60
+      EvaluationPeriods: 1
+      Statistic: Sum
+      TreatMissingData: notBreaching
+    DependsOn: ContentLambdaV2
 
   LiveBlogLambdaV2:
     Type: AWS::Lambda::Function

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -155,7 +155,7 @@ Resources:
           - '-'
           - - 'contentLambdaErrorPercentageAlarm'
             - !Ref Stage
-      AlarmDescription:  'Impact - Users that are subscribed to content notifications may not be getting the latest updates'm
+      AlarmDescription:  'Impact - Users that are subscribed to content notifications may not be getting the latest updates'
       ComparisonOperator: GreaterThanThreshold
       EvaluationPeriods: 1
       Metrics:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -112,6 +112,14 @@ Resources:
                Action:
                   - cloudwatch:PutMetricData
                Resource: "*"
+        - PolicyName: sns-alarm-topic
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - sns:Publish
+              Resource:
+                - !Sub arn:aws:sns:${AWS::Region}:${AWS::MobileAccountId}:mobile-server-side-${Stage}
 
   ContentLambdaV2:
     Type: AWS::Lambda::Function
@@ -149,7 +157,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side-${Stage}
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::MobileAccountId}:mobile-server-side-${Stage}
       AlarmName:
         Fn::Join:
           - '-'
@@ -191,7 +199,7 @@ Resources:
             Stat: Sum
           ReturnData: false
       OKActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side-${Stage}
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::MobileAccountId}:mobile-server-side-${Stage}
       Threshold: 1
       TreatMissingData: notBreaching
     DependsOn: ContentLambdaV2
@@ -232,7 +240,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side-${Stage}
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::MobileAccountId}:mobile-server-side-${Stage}
       AlarmName:
         Fn::Join:
           - '-'
@@ -274,7 +282,7 @@ Resources:
             Stat: Sum
           ReturnData: false
       OKActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side-${Stage}
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::MobileAccountId}:mobile-server-side-${Stage}
       Threshold: 1
       TreatMissingData: notBreaching
     DependsOn: LiveBlogLambdaV2

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -69,12 +69,6 @@ Resources:
               Effect: Allow
               Action: sts:AssumeRole
               Resource: !Sub arn:aws:iam::${MobileAccountId}:role/${CrossAccountBaseRoleName}-dynamo-${Stage}
-        - PolicyName: assume-mobile-sns-alarm-topic
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action: sts:AssumeRole
-              Resource: !Sub arn:aws:iam::${MobileAccountId}:role/${CrossAccountBaseRoleName}-sns-${Stage}
         - PolicyName: logs
           PolicyDocument:
             Statement:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -155,7 +155,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${MobileAccountId}:mobile-server-side-${Stage}
+        - !Sub arn:aws:sns:${AWS::Region}:${MobileAccountId}:mobile-server-side
       AlarmName:
         Fn::Join:
           - '-'
@@ -197,7 +197,7 @@ Resources:
             Stat: Sum
           ReturnData: false
       OKActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${MobileAccountId}:mobile-server-side-${Stage}
+        - !Sub arn:aws:sns:${AWS::Region}:${MobileAccountId}:mobile-server-side
       Threshold: 1
       TreatMissingData: notBreaching
     DependsOn: ContentLambdaV2
@@ -238,7 +238,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${MobileAccountId}:mobile-server-side-${Stage}
+        - !Sub arn:aws:sns:${AWS::Region}:${MobileAccountId}:mobile-server-side
       AlarmName:
         Fn::Join:
           - '-'
@@ -280,7 +280,7 @@ Resources:
             Stat: Sum
           ReturnData: false
       OKActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${MobileAccountId}:mobile-server-side-${Stage}
+        - !Sub arn:aws:sns:${AWS::Region}:${MobileAccountId}:mobile-server-side
       Threshold: 1
       TreatMissingData: notBreaching
     DependsOn: LiveBlogLambdaV2

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -69,6 +69,12 @@ Resources:
               Effect: Allow
               Action: sts:AssumeRole
               Resource: !Sub arn:aws:iam::${MobileAccountId}:role/${CrossAccountBaseRoleName}-dynamo-${Stage}
+        - PolicyName: assume-mobile-sns-alarm-topic
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action: sts:AssumeRole
+              Resource: !Sub arn:aws:iam::${MobileAccountId}:role/${CrossAccountBaseRoleName}-sns-${Stage}
         - PolicyName: logs
           PolicyDocument:
             Statement:
@@ -112,14 +118,6 @@ Resources:
                Action:
                   - cloudwatch:PutMetricData
                Resource: "*"
-        - PolicyName: sns-alarm-topic
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - sns:Publish
-              Resource:
-                - !Sub arn:aws:sns:${AWS::Region}:${MobileAccountId}:mobile-server-side-${Stage}
 
   ContentLambdaV2:
     Type: AWS::Lambda::Function

--- a/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
@@ -59,6 +59,7 @@ trait Lambda extends Logging {
     val records = eventRecords.map(kinesisEventRecordToRecord)
     val aggregatorUtil = new AggregatorUtil()
     val userRecords: List[KinesisClientRecord] = aggregatorUtil.deaggregate(records.asJava).asScala.toList
+    throw new RuntimeException("testing alarm")
     CapiEventProcessor.process(userRecords) { event =>
       event.eventType match {
         case EventType.Update =>

--- a/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
@@ -59,7 +59,6 @@ trait Lambda extends Logging {
     val records = eventRecords.map(kinesisEventRecordToRecord)
     val aggregatorUtil = new AggregatorUtil()
     val userRecords: List[KinesisClientRecord] = aggregatorUtil.deaggregate(records.asJava).asScala.toList
-    throw new RuntimeException("testing alarm")
     CapiEventProcessor.process(userRecords) { event =>
       event.eventType match {
         case EventType.Update =>

--- a/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
@@ -59,7 +59,6 @@ trait Lambda extends Logging {
     val records = eventRecords.map(kinesisEventRecordToRecord)
     val aggregatorUtil = new AggregatorUtil()
     val userRecords: List[KinesisClientRecord] = aggregatorUtil.deaggregate(records.asJava).asScala.toList
-    throw new RuntimeException("exception")
     CapiEventProcessor.process(userRecords) { event =>
       event.eventType match {
         case EventType.Update =>

--- a/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
@@ -59,6 +59,7 @@ trait Lambda extends Logging {
     val records = eventRecords.map(kinesisEventRecordToRecord)
     val aggregatorUtil = new AggregatorUtil()
     val userRecords: List[KinesisClientRecord] = aggregatorUtil.deaggregate(records.asJava).asScala.toList
+    throw new RuntimeException("exception")
     CapiEventProcessor.process(userRecords) { event =>
       event.eventType match {
         case EventType.Update =>

--- a/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
+++ b/src/main/scala/com/gu/mobile/content/notifications/Lambda.scala
@@ -59,7 +59,7 @@ trait Lambda extends Logging {
     val records = eventRecords.map(kinesisEventRecordToRecord)
     val aggregatorUtil = new AggregatorUtil()
     val userRecords: List[KinesisClientRecord] = aggregatorUtil.deaggregate(records.asJava).asScala.toList
-
+    throw new RuntimeException("testing alarm")
     CapiEventProcessor.process(userRecords) { event =>
       event.eventType match {
         case EventType.Update =>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This adds an alarm for the lambdas when they don't finish executing successfully. 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
