### PR TITLE
Bump kafka client to fix snyk vulnerability

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-java corretto-21
+java corretto-21.0.5.11.1

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,10 @@ resolvers ++= Seq(
   "Guardian GitHub Snapshots" at "https://guardian.github.com/maven/repo-snapshots"
 )
 
+ThisBuild / libraryDependencySchemes ++= Seq(
+  "com.github.luben" % "zstd-jni" % VersionScheme.Always
+)
+
 assembly / assemblyMergeStrategy := {
   case "META-INF/MANIFEST.MF" => MergeStrategy.discard
   case _ => MergeStrategy.first
@@ -55,12 +59,13 @@ libraryDependencies ++= Seq(
   "org.json" % "json" % "20240303",
   "org.apache.commons" % "commons-compress" % "1.27.1",
   "org.apache.avro" % "avro" % "1.12.0",
+  "org.apache.kafka" % "kafka-clients" % "3.7.2",
   "org.scalatest" %% "scalatest" % "3.2.19" % Test,
   "org.specs2" %% "specs2-core" % "4.20.9" % Test,
   "org.specs2" %% "specs2-matcher-extra" % "4.20.9" % Test,
   "org.mockito" % "mockito-core" % "5.14.2" % Test,
   "org.scalatestplus" %% "mockito-5-12" % "3.2.19.0" % Test,
 )
-libraryDependencies += "com.github.luben" % "zstd-jni" % "1.5.5-3"
+libraryDependencies += "com.github.luben" % "zstd-jni" % "1.5.6-9"
 
 assemblyJarName := s"${name.value}.jar"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This pull request bumps the kafka client library to 3.7.2 to fix a high severity vulnerability detected by Snyk.

However, it results in library conflicts over `zstd-jni`.  One of our dependency, `thrift-serializer` (in its latest version), depends on an old version of `zstd-jni`.  

<img width="640px" src="https://github.com/user-attachments/assets/4b5449f6-f291-4b59-8687-f31670c571d5" />

This PR configures the dependency versioning schema on `zstd-jni` to accept the newer version to resolve the error.
