### PR TITLE
Update aws sdk to 2.46.21

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ assembly / assemblyMergeStrategy := {
   case _ => MergeStrategy.first
 }
 
-val awsSdkVersion = "2.31.77"
+val awsSdkVersion = "2.46.21"
 
 libraryDependencies ++= Seq(
   "software.amazon.awssdk" % "sts" % awsSdkVersion,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Bumps software.amazon.awssdk from 2.31.77 to 2.46.21 to pull in `netty-codec-http2 4.1.135.Final`, resolving the transitive Netty dependency in 4.1.130.

**Before**
<img width="682" height="209" alt="image" src="https://github.com/user-attachments/assets/87a31789-4e9d-45b5-96f4-e23669c24010" />

**After**
<img width="781" height="342" alt="image" src="https://github.com/user-attachments/assets/56ea1f7e-04df-4ac3-8b7e-9c9d3fa153ba" />


## How has this change been tested?
Deployed to CODE and followed the testing steps in ReadMe


