### PR TITLE
Bumb `mobile-notifications-api-models`, `amazon-kinesis-client` and remove `jackson-databind`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ libraryDependencies ++= Seq(
   "software.amazon.awssdk" % "autoscaling" % awsSdkVersion,
   "software.amazon.awssdk" % "ec2" % awsSdkVersion,
   "software.amazon.awssdk" % "ssm" % awsSdkVersion,
-  "software.amazon.kinesis" % "amazon-kinesis-client" % "3.4.0",
+  "software.amazon.kinesis" % "amazon-kinesis-client" % "3.5.1",
   "software.amazon.awssdk" % "cloudwatch" % awsSdkVersion,
   "software.amazon.awssdk" % "dynamodb" % awsSdkVersion,
   "com.amazonaws" % "aws-lambda-java-core" % "1.3.0",

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,6 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor" % "2.5.24",
   "com.squareup.okhttp3" % "okhttp" % "3.14.9",
   "com.gu" %% "simple-configuration-ssm" % "5.1.2",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.21.5",
   "com.squareup.okhttp3" % "okhttp" % "4.12.0",
   "com.google.protobuf" % "protobuf-java" % "4.31.1",
   "org.json" % "json" % "20250517",

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,6 @@ libraryDependencies ++= Seq(
   "com.google.protobuf" % "protobuf-java" % "4.31.1",
   "org.json" % "json" % "20250517",
   "org.apache.commons" % "commons-compress" % "1.27.1",
-  "org.apache.avro" % "avro" % "1.12.0",
   "org.scalatest" %% "scalatest" % "3.2.19" % Test,
   "org.specs2" %% "specs2-core" % "4.21.0" % Test,
   "org.specs2" %% "specs2-matcher-extra" % "4.21.0" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor" % "2.5.24",
   "com.squareup.okhttp3" % "okhttp" % "3.14.9",
   "com.gu" %% "simple-configuration-ssm" % "5.1.2",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.21.1",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.21.5",
   "com.squareup.okhttp3" % "okhttp" % "4.12.0",
   "com.google.protobuf" % "protobuf-java" % "4.31.1",
   "org.json" % "json" % "20250517",

--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,7 @@ libraryDependencies ++= Seq(
   "com.google.protobuf" % "protobuf-java" % "4.31.1",
   "org.json" % "json" % "20250517",
   "org.apache.commons" % "commons-compress" % "1.27.1",
+  "org.apache.avro" % "avro" % "1.12.1",
   "org.scalatest" %% "scalatest" % "3.2.19" % Test,
   "org.specs2" %% "specs2-core" % "4.21.0" % Test,
   "org.specs2" %% "specs2-matcher-extra" % "4.21.0" % Test,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?



## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
